### PR TITLE
Update master to track Bevy main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ Cargo.lock
 .vscode
 .cargo/credentials.toml
 .cargo/config_fast_compile
+*.iml
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["game-engines", "rendering"]
 
 [dependencies]
 #bevy = { version = "0.4", default-features = false, features = ["render"] }
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "master", default-features = false, features = ["render"] }
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["render"] }
 
 [features]
 ex = [ "bevy/bevy_wgpu", "bevy/bevy_winit", "bevy/bevy_gltf", "bevy/x11" ]

--- a/examples/mouse_picking.rs
+++ b/examples/mouse_picking.rs
@@ -18,11 +18,11 @@ fn main() {
         // the positions of your meshes have been updated in the UPDATE stage.
         .add_system(update_raycast_with_cursor.system()) // Update our ray casting source in the UPDATE stage
         .add_system_to_stage(
-            stage::POST_UPDATE, // We want this system to run after we've updated our ray casting source
+            CoreStage::PostUpdate, // We want this system to run after we've updated our ray casting source
             update_raycast::<MyRaycastSet>.system(), // This provided system does the ray casting
         )
         .add_system_to_stage(
-            stage::POST_UPDATE, // We want this system to run after ray casting has been computed
+            CoreStage::PostUpdate, // We want this system to run after ray casting has been computed
             update_debug_cursor::<MyRaycastSet>.system(), // Update the debug cursor location
         )
         .add_startup_system(setup.system())
@@ -49,7 +49,7 @@ fn update_raycast_with_cursor(
 
 // Set up a simple 3D scene
 fn setup(
-    commands: &mut Commands,
+    mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {

--- a/examples/mouse_picking.rs
+++ b/examples/mouse_picking.rs
@@ -69,7 +69,7 @@ fn setup(
                 radius: 2.0,
             })),
             material: materials.add(Color::rgb(1.0, 1.0, 1.0).into()),
-            transform: Transform::from_translation(Vec3::zero()),
+            transform: Transform::from_translation(Vec3::ZERO),
             ..Default::default()
         })
         .with(RayCastMesh::<MyRaycastSet>::default()) // Make this mesh ray cast-able

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -37,13 +37,13 @@ impl<T> Default for DebugCursorMesh<T> {
 
 /// Updates the 3d cursor to be in the pointed world coordinates
 pub fn update_debug_cursor<T: 'static + Send + Sync>(
-    commands: &mut Commands,
+    mut commands: Commands,
     state: Res<PluginState<T>>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     added_sources_query: Query<&RayCastSource<T>, Added<RayCastSource<T>>>,
     mut cursor_query: Query<&mut GlobalTransform, With<DebugCursor<T>>>,
-    mut cursor_tail_query: Query<&mut GlobalTransform, With<DebugCursorTail<T>>>,
+    mut cursor_tail_query: Query<&mut GlobalTransform, (With<DebugCursorTail<T>>, Without<DebugCursor<T>>)>,
     mut visibility_query: Query<&mut Visible, With<DebugCursorMesh<T>>>,
     raycast_source_query: Query<&RayCastSource<T>>,
 ) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ impl<T> RayCastSource<T> {
     /// runs, or one of the `with_ray` functions is run.
     pub fn new() -> Self {
         RayCastSource {
-            cast_method: RayCastMethod::Screenspace(Vec2::zero()),
+            cast_method: RayCastMethod::Screenspace(Vec2::ZERO),
             ray: None,
             intersections: Vec::new(),
             _marker: PhantomData::default(),
@@ -359,11 +359,11 @@ fn ray_mesh_intersection(
         // chunk of three indices are references to the three vertices of a triangle.
         for index in indices.chunks(3) {
             // Construct a triangle in world space using the mesh data
-            let mut world_vertices: [Vec3; 3] = [Vec3::zero(), Vec3::zero(), Vec3::zero()];
+            let mut world_vertices: [Vec3; 3] = [Vec3::ZERO, Vec3::ZERO, Vec3::ZERO];
             for i in 0..3 {
                 let vertex_index = index[i] as usize;
                 world_vertices[i] =
-                    mesh_to_world.transform_point3(Vec3::from(vertex_positions[vertex_index]));
+                    mesh_to_world.project_point3(Vec3::from(vertex_positions[vertex_index]));
             }
             // If all vertices in the triangle are further away than the nearest hit, skip
             if world_vertices

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -87,7 +87,7 @@ pub mod rays {
         }
         pub fn from_transform(transform: Mat4) -> Self {
             let pick_position_ndc = Vec3::from([0.0, 0.0, 1.0]);
-            let pick_position = transform.transform_point3(pick_position_ndc);
+            let pick_position = transform.project_point3(pick_position_ndc);
             let (_, _, source_origin) = transform.to_scale_rotation_translation();
             let ray_direction = pick_position - source_origin;
             Ray3d::new(source_origin, ray_direction)
@@ -114,8 +114,8 @@ pub mod rays {
             // This method is more robust than using the location of the camera as the start of
             // the ray, because ortho cameras have a focal point at infinity!
             let ndc_to_world: Mat4 = camera_position * projection_matrix.inverse();
-            let cursor_pos_near: Vec3 = ndc_to_world.transform_point3(cursor_pos_ndc_near);
-            let cursor_pos_far: Vec3 = ndc_to_world.transform_point3(cursor_pos_ndc_far);
+            let cursor_pos_near: Vec3 = ndc_to_world.project_point3(cursor_pos_ndc_near);
+            let cursor_pos_far: Vec3 = ndc_to_world.project_point3(cursor_pos_ndc_far);
             let ray_direction = cursor_pos_far - cursor_pos_near;
             Ray3d::new(cursor_pos_near, ray_direction)
         }

--- a/src/raycast.rs
+++ b/src/raycast.rs
@@ -12,7 +12,7 @@ pub enum RaycastAlgorithm {
 
 impl Default for RaycastAlgorithm {
     fn default() -> Self {
-        RaycastAlgorithm::MollerTrumbore(Backfaces::Cull)
+        RaycastAlgorithm::MollerTrumbore(Backfaces::Include)
     }
 }
 
@@ -160,7 +160,7 @@ mod tests {
     #[test]
     fn raycast_triangle_mt() {
         let triangle = Triangle::from([V0.into(), V1.into(), V2.into()]);
-        let ray = Ray3d::new(Vec3::zero(), Vec3::unit_x());
+        let ray = Ray3d::new(Vec3::ZERO, Vec3::X);
         let algorithm = RaycastAlgorithm::MollerTrumbore(Backfaces::Include);
         let result = ray_triangle_intersection(&ray, &triangle, algorithm);
         assert_eq!(
@@ -172,7 +172,7 @@ mod tests {
     #[test]
     fn raycast_triangle_mt_culling() {
         let triangle = Triangle::from([V2.into(), V1.into(), V0.into()]);
-        let ray = Ray3d::new(Vec3::zero(), Vec3::unit_x());
+        let ray = Ray3d::new(Vec3::ZERO, Vec3::X);
         let algorithm = RaycastAlgorithm::MollerTrumbore(Backfaces::Cull);
         let result = ray_triangle_intersection(&ray, &triangle, algorithm);
         assert_eq!(result, None);
@@ -181,7 +181,7 @@ mod tests {
     #[test]
     fn raycast_triangle_geometric() {
         let triangle = Triangle::from([V0.into(), V1.into(), V2.into()]);
-        let ray = Ray3d::new(Vec3::zero(), Vec3::unit_x());
+        let ray = Ray3d::new(Vec3::ZERO, Vec3::X);
         let algorithm = RaycastAlgorithm::Geometric;
         let result = ray_triangle_intersection(&ray, &triangle, algorithm);
         assert_eq!(

--- a/src/raycast.rs
+++ b/src/raycast.rs
@@ -12,7 +12,7 @@ pub enum RaycastAlgorithm {
 
 impl Default for RaycastAlgorithm {
     fn default() -> Self {
-        RaycastAlgorithm::MollerTrumbore(Backfaces::Include)
+        RaycastAlgorithm::MollerTrumbore(Backfaces::Cull)
     }
 }
 


### PR DESCRIPTION
I removed the parallel iteration because of the removal of `par_iter()`. It being replaced with `.par_for_each()` and `.par_for_each_mut()` means that we have no mechanism for aggregating results outside of a concurrent container. Using an `Arc<Mutex<Vec>>` might work, and I quickly tried it, but the example stopped functioning and I didn't debug further. I'm not sure if the cost of a Mutex outweighs the cost of not parallelizing here.

The change of note is glam's moving of `transform_point3()` to `project_point3()` and replacing it with a function that does the same thing sans multiplication by the projection matrix.