### PR TITLE
adding benchmarks on `ray_mesh_intersection`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,8 @@ bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", version = 
     "bevy_gltf",
     "x11",
 ] }
+criterion = "0.3"
+
+[[bench]]
+name = "ray_mesh_intersection"
+harness = false

--- a/benches/ray_mesh_intersection.rs
+++ b/benches/ray_mesh_intersection.rs
@@ -1,0 +1,93 @@
+use bevy::math::{Mat4, Vec3};
+use bevy_mod_raycast::Ray3d;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn ptoxznorm(p: u32, size: u32) -> (f32, f32) {
+    let ij = (p / (size), p % (size));
+    (ij.0 as f32 / size as f32, ij.1 as f32 / size as f32)
+}
+
+struct SimpleMesh {
+    positions: Vec<[f32; 3]>,
+    normals: Vec<[f32; 3]>,
+    indices: Vec<u32>,
+}
+
+fn mesh_creation(vertices_per_side: u32) -> SimpleMesh {
+    let mut positions = Vec::new();
+    let mut normals = Vec::new();
+    for p in 0..vertices_per_side.pow(2) {
+        let xz = ptoxznorm(p, vertices_per_side);
+        positions.push([xz.0 - 0.5, 0.0, xz.1 - 0.5]);
+        normals.push([0.0, 1.0, 0.0]);
+    }
+
+    let mut indices = vec![];
+    for p in 0..vertices_per_side.pow(2) {
+        if p % (vertices_per_side) != vertices_per_side - 1
+            && p / (vertices_per_side) != vertices_per_side - 1
+        {
+            indices.extend_from_slice(&[p, p + 1, p + vertices_per_side]);
+            indices.extend_from_slice(&[p + vertices_per_side, p + 1, p + vertices_per_side + 1]);
+        }
+    }
+
+    SimpleMesh {
+        positions,
+        normals,
+        indices,
+    }
+}
+
+fn ray_mesh_intersection(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ray_mesh_intersection");
+    group.warm_up_time(std::time::Duration::from_millis(500));
+
+    for vertices_per_side in [10_u32, 100, 1000] {
+        group.bench_function(format!("{}_vertices", vertices_per_side.pow(2)), |b| {
+            let ray = Ray3d::new(Vec3::new(0.0, 1.0, 0.0), Vec3::new(0.0, -1.0, 0.0));
+            let mesh_to_world = Mat4::IDENTITY;
+            let mesh = mesh_creation(vertices_per_side);
+
+            b.iter(|| {
+                black_box(bevy_mod_raycast::ray_mesh_intersection(
+                    &mesh_to_world,
+                    &mesh.positions,
+                    Some(&mesh.normals),
+                    &ray,
+                    Some(&mesh.indices),
+                ));
+            });
+        });
+    }
+}
+
+fn ray_mesh_intersection_no_intersection(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ray_mesh_intersection_no_intersection");
+    group.warm_up_time(std::time::Duration::from_millis(500));
+
+    for vertices_per_side in [10_u32, 100, 1000] {
+        group.bench_function(format!("{}_vertices", vertices_per_side.pow(2)), |b| {
+            let ray = Ray3d::new(Vec3::new(0.0, 1.0, 0.0), Vec3::new(1.0, 0.0, 0.0));
+            let mesh_to_world = Mat4::IDENTITY;
+            let mesh = mesh_creation(vertices_per_side);
+
+            b.iter(|| {
+                black_box(bevy_mod_raycast::ray_mesh_intersection(
+                    &mesh_to_world,
+                    &mesh.positions,
+                    Some(&mesh.normals),
+                    &ray,
+                    Some(&mesh.indices),
+                ));
+            });
+        });
+    }
+}
+
+criterion_group!(
+    benches,
+    ray_mesh_intersection,
+    ray_mesh_intersection_no_intersection
+);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,7 +447,7 @@ pub fn update_raycast<T: 'static + Send + Sync>(
 }
 
 /// Checks if a ray intersects a mesh, and returns the nearest intersection if one exists.
-fn ray_mesh_intersection(
+pub fn ray_mesh_intersection(
     mesh_to_world: &Mat4,
     vertex_positions: &[[f32; 3]],
     vertex_normals: Option<&[[f32; 3]]>,


### PR DESCRIPTION
This PR makes `ray_mesh_intersection` public and adds benchmarks on it

My computer is very not good for running benchmarks, but I get those results:
```
ray_mesh_intersection/100_vertices
                        time:   [3.5276 us 3.5889 us 3.6599 us]
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
ray_mesh_intersection/10000_vertices
                        time:   [417.07 us 426.85 us 439.25 us]
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe
ray_mesh_intersection/1000000_vertices
                        time:   [44.719 ms 45.009 ms 45.327 ms]
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

ray_mesh_intersection_no_intersection/100_vertices
                        time:   [3.3899 us 3.4160 us 3.4398 us]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
ray_mesh_intersection_no_intersection/10000_vertices
                        time:   [411.82 us 418.62 us 427.14 us]
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  7 (7.00%) high severe
ray_mesh_intersection_no_intersection/1000000_vertices
                        time:   [47.149 ms 47.468 ms 47.787 ms]
```

the tests:
* create a square mesh with side of 10 points, 100, 1000
* recast in the middle of the mesh
* recast above the mesh without collision
