### PR TITLE
Optimisations on `triangle_intersection`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -564,10 +564,9 @@ fn triangle_intersection(
         .iter()
         .any(|&vertex| (vertex - ray.origin()).length_squared() < max_distance.powi(2))
     {
-        let triangle = Triangle::from(tri_vertices);
         // Run the raycast on the ray and triangle
         if let Some(ray_hit) =
-            ray_triangle_intersection(&ray, &triangle, RaycastAlgorithm::default())
+            ray_triangle_intersection(&ray, &tri_vertices, RaycastAlgorithm::default())
         {
             let distance = *ray_hit.distance();
             if distance > 0.0 && distance < max_distance {
@@ -578,16 +577,56 @@ fn triangle_intersection(
                     let w = 1.0 - u - v;
                     normals[1] * u + normals[2] * v + normals[0] * w
                 } else {
-                    (triangle.v1 - triangle.v0)
-                        .cross(triangle.v2 - triangle.v0)
+                    (tri_vertices.v1() - tri_vertices.v0())
+                        .cross(tri_vertices.v2() - tri_vertices.v0())
                         .normalize()
                 };
-                let intersection = Intersection::new(position, normal, distance, Some(triangle));
+                let intersection =
+                    Intersection::new(position, normal, distance, Some(tri_vertices.to_triangle()));
                 return Some(intersection);
             }
         }
     }
     None
+}
+
+pub trait TriangleTrait {
+    fn v0(&self) -> Vec3;
+    fn v1(&self) -> Vec3;
+    fn v2(&self) -> Vec3;
+    fn to_triangle(self) -> Triangle;
+}
+impl TriangleTrait for [Vec3; 3] {
+    fn v0(&self) -> Vec3 {
+        self[0]
+    }
+    fn v1(&self) -> Vec3 {
+        self[1]
+    }
+    fn v2(&self) -> Vec3 {
+        self[2]
+    }
+
+    fn to_triangle(self) -> Triangle {
+        Triangle::from(self)
+    }
+}
+impl TriangleTrait for Triangle {
+    fn v0(&self) -> Vec3 {
+        self.v0
+    }
+
+    fn v1(&self) -> Vec3 {
+        self.v1
+    }
+
+    fn v2(&self) -> Vec3 {
+        self.v2
+    }
+
+    fn to_triangle(self) -> Triangle {
+        self
+    }
 }
 
 pub struct SimplifiedMesh {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -562,9 +562,7 @@ fn triangle_intersection(
 ) -> Option<Intersection> {
     if tri_vertices
         .iter()
-        .filter(|&&vertex| (vertex - ray.origin()).length_squared() < max_distance.powi(2))
-        .count()
-        != 0
+        .any(|&vertex| (vertex - ray.origin()).length_squared() < max_distance.powi(2))
     {
         let triangle = Triangle::from(tri_vertices);
         // Run the raycast on the ray and triangle

--- a/src/raycast.rs
+++ b/src/raycast.rs
@@ -1,6 +1,6 @@
 use std::f32::EPSILON;
 
-use crate::primitives::*;
+use crate::{primitives::*, TriangleTrait};
 use bevy::prelude::*;
 
 #[allow(dead_code)]
@@ -25,7 +25,7 @@ pub enum Backfaces {
 #[inline(always)]
 pub fn ray_triangle_intersection(
     ray: &Ray3d,
-    triangle: &Triangle,
+    triangle: &impl TriangleTrait,
     algorithm: RaycastAlgorithm,
 ) -> Option<RayHit> {
     match algorithm {
@@ -57,12 +57,12 @@ impl RayHit {
 #[inline(always)]
 pub fn raycast_moller_trumbore(
     ray: &Ray3d,
-    triangle: &Triangle,
+    triangle: &impl TriangleTrait,
     backface_culling: Backfaces,
 ) -> Option<RayHit> {
     // Source: https://www.scratchapixel.com/lessons/3d-basic-rendering/ray-tracing-rendering-a-triangle/moller-trumbore-ray-triangle-intersection
-    let vector_v0_to_v1: Vec3 = triangle.v1 - triangle.v0;
-    let vector_v0_to_v2: Vec3 = triangle.v2 - triangle.v0;
+    let vector_v0_to_v1: Vec3 = triangle.v1() - triangle.v0();
+    let vector_v0_to_v2: Vec3 = triangle.v2() - triangle.v0();
     let p_vec: Vec3 = ray.direction().cross(vector_v0_to_v2);
     let determinant: f32 = vector_v0_to_v1.dot(p_vec);
 
@@ -85,7 +85,7 @@ pub fn raycast_moller_trumbore(
 
     let determinant_inverse = 1.0 / determinant;
 
-    let t_vec: Vec3 = ray.origin() - triangle.v0;
+    let t_vec: Vec3 = ray.origin() - triangle.v0();
     let u = t_vec.dot(p_vec) * determinant_inverse;
     if !(0.0..=1.0).contains(&u) {
         return None;


### PR DESCRIPTION
Building on #17, this should bring some optimisations
```
ray_mesh_intersection/100_vertices
                        time:   [2.5537 us 2.5698 us 2.5862 us]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
ray_mesh_intersection/10000_vertices
                        time:   [302.76 us 304.54 us 306.30 us]
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
ray_mesh_intersection/1000000_vertices
                        time:   [35.273 ms 35.525 ms 35.841 ms]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe

ray_mesh_intersection_no_intersection/100_vertices
                        time:   [2.4214 us 2.4359 us 2.4505 us]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
ray_mesh_intersection_no_intersection/10000_vertices
                        time:   [291.88 us 293.84 us 295.84 us]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
ray_mesh_intersection_no_intersection/1000000_vertices
                        time:   [35.197 ms 35.413 ms 35.638 ms]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
```

* First commit: stop on first vertex that is closer instead of checking all 3
* Second commit: introduce a trait `TriangleTrait` instead of changing to the `Triangle` struct. The struct implies a copy while the trait doesn't. This probably could be done cleanlier but I was aiming for the smallest change