### PR TITLE
fix clippy lint

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -81,7 +81,7 @@ pub mod rays {
         pub fn position(&self, distance: f32) -> Vec3 {
             self.origin + self.direction * distance
         }
-        pub fn to_transform(&self) -> Mat4 {
+        pub fn to_transform(self) -> Mat4 {
             let position = self.origin;
             let normal = self.direction;
             let up = Vec3::from([0.0, 1.0, 0.0]);


### PR DESCRIPTION
`to_transform` name implies it takes ownership

It's used only once and it can take it in this case