### PR TITLE
Add debug feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/aevyrie/bevy_mod_raycast/"
 keywords = ["gamedev", "graphics", "bevy", "3d", "raycast"]
 categories = ["game-engines", "rendering"]
 
+[features]
+default = ["debug"]
+debug = []
+
 [dependencies]
 bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", version = "0.5", default-features = false, features = ["render"] }
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ I intend to track the `main` branch of Bevy. PRs supporting this are welcome!
 |0.5|0.2|
 |0.4|0.1|
 
+## Crate Features
+
+* `debug` enables a debugging cursor at runtime (enabled by default)
+
 ## Examples
 
 Mouse picking using a ray cast built using screen space coordinates:


### PR DESCRIPTION
As per suggestions in #12 I created a separate PR just for the debug feature flag.

Of note for possible discussion is that I didn't exclude debug related declarations in lib.rs:
* `pub enum RaycastSystem`still contains an ungated `UpdateDebugCursor`
* `pub struct DefaultPluginState` still has an ungated `pub update_debug_cursor`
* `DefaultPluginState` still has an ungated `pub fn with_debug_cursor` but without the functionality

The effective change is to not include the `debug` crate and not add the `update_debug_cursor` system

This is so that users of this crate don't have to gate their usages of these declarations.
Another approach would be to completely remove debug related things such as the ones mentioned above.
