### PR TITLE
Bevy 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ categories = ["game-engines", "rendering"]
 resolver = "2"
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", version = "0.5", default-features = false, features = [
+bevy = { version = "0.6", default-features = false, features = [
     "render",
 ] }
 wgpu = "*"
 
 [dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", version = "0.5", default-features = false, features = [
+bevy = { version = "0.6", default-features = false, features = [
     "render",
     "bevy_winit",
     "bevy_gltf",


### PR DESCRIPTION
So, I'm not really sure if this should be merged into `master`, since the the readme says you intend to track the bevy `main` branch, but I think perhaps it would be useful to have a branch that targets 0.6 as well?

Or perhaps you intend to publish it only ion crates.io and not on github?

In any case, I ran all the examples, and they seem to be working, thanks for the great work :)