### PR TITLE
fix multiple raycast sources with screenspace rays

### DIFF
--- a/examples/mouse_picking.rs
+++ b/examples/mouse_picking.rs
@@ -37,11 +37,14 @@ fn update_raycast_with_cursor(
     mut cursor: EventReader<CursorMoved>,
     mut query: Query<&mut RayCastSource<MyRaycastSet>>,
 ) {
+    // Grab the most recent cursor event if it exists:
+    let cursor_position = match cursor.iter().last() {
+        Some(cursor_moved) => cursor_moved.position,
+        None => return,
+    };
+
     for mut pick_source in &mut query.iter_mut() {
-        // Grab the most recent cursor event if it exists:
-        if let Some(cursor_latest) = cursor.iter().last() {
-            pick_source.cast_method = RayCastMethod::Screenspace(cursor_latest.position);
-        }
+        pick_source.cast_method = RayCastMethod::Screenspace(cursor_position);
     }
 }
 


### PR DESCRIPTION
The issue was that for every camera, the events were iterated, meaning that on the second camera the events had already been cleared. By inverting the order, multiple screenspace raycast sources in the same set work now.

Note that multiple debug cursors don't work because the code assumes a one-to-one mapping between picking sets and debug cursors. Maybe the plugin state configuration 
```rust
    pub build_rays: bool,
    pub update_raycast: bool,
    pub update_debug_cursor: bool,
```
could be moved to the `RayCastSource`? It seems to me like these booleans should be a property of the source, not the picking set.