### PR TITLE
Support Screenspace raycasting for cameras rendering to a texture

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,13 +156,20 @@ impl<T> RayCastSource<T> {
     pub fn with_ray_screenspace(
         &self,
         cursor_pos_screen: Vec2,
+        images: &Res<Assets<Image>>,
         windows: &Res<Windows>,
         camera: &Camera,
         camera_transform: &GlobalTransform,
     ) -> Self {
         RayCastSource {
             cast_method: RayCastMethod::Screenspace(cursor_pos_screen),
-            ray: Ray3d::from_screenspace(cursor_pos_screen, windows, camera, camera_transform),
+            ray: Ray3d::from_screenspace(
+                cursor_pos_screen,
+                images,
+                windows,
+                camera,
+                camera_transform,
+            ),
             intersections: self.intersections.clone(),
             _marker: self._marker,
         }
@@ -179,12 +186,14 @@ impl<T> RayCastSource<T> {
     /// Instantiates and initializes a [RayCastSource] with a valid screenspace ray.
     pub fn new_screenspace(
         cursor_pos_screen: Vec2,
+        images: &Res<Assets<Image>>,
         windows: &Res<Windows>,
         camera: &Camera,
         camera_transform: &GlobalTransform,
     ) -> Self {
         RayCastSource::new().with_ray_screenspace(
             cursor_pos_screen,
+            images,
             windows,
             camera,
             camera_transform,
@@ -278,6 +287,7 @@ pub enum RayCastMethod {
 
 #[allow(clippy::type_complexity)]
 pub fn build_rays<T: 'static + Send + Sync>(
+    images: Res<Assets<Image>>,
     windows: Res<Windows>,
     mut pick_source_query: Query<(
         &mut RayCastSource<T>,
@@ -307,7 +317,13 @@ pub fn build_rays<T: 'static + Send + Sync>(
                         return;
                     }
                 };
-                Ray3d::from_screenspace(*cursor_pos_screen, &windows, camera, camera_transform)
+                Ray3d::from_screenspace(
+                    *cursor_pos_screen,
+                    &images,
+                    &windows,
+                    camera,
+                    camera_transform,
+                )
             }
             // Use the specified transform as the origin and direction of the ray
             RayCastMethod::Transform => {


### PR DESCRIPTION
Hi!
Since the render-to-texture cameras feature [has been merged](https://github.com/bevyengine/bevy/pull/3412) in bevy's main branch, here is a simple change to allow supporting 1st pass cameras rendering to an `Image`.

Maybe there is another cleaner way to do this. I find it a bit intrusive to have to gather `Res<Assets<Images>>` along `Res<Windows>` just to be able to support both cases.
With generics? Unfortunately I'm not fluent enough with Rust generics to find a way to do it (I wanted to make `get_camera_rendering_size` a generic with "template _argument_" from C++ with RenderTarget enum values, but it seems we can't do that yet in Rust).