### PR TITLE
Updated to bevy 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_mod_raycast"
-version = "0.3.9"
+version = "0.4.0"
 authors = ["Aevyrie <aevyrie@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ resolver = "2"
 #bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
 #    "render",
 #] }
-bevy = { version = "0.6", default-features = false, features = ["render"] }
+bevy = { version = "0.7", default-features = false, features = ["render"] }
 
 [dev-dependencies]
 #bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
-bevy = { version = "0.6", default-features = false, features = [
+bevy = { version = "0.7", default-features = false, features = [
     "bevy_winit",
     "x11",
 ] }

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ I intend to track the `main` branch of Bevy. PRs supporting this are welcome!
 
 |bevy|bevy_mod_raycast|
 |---|---|
+|0.7|0.4|
 |0.6|0.3|
 |0.5|0.2|
 |0.4|0.1|

--- a/examples/bounding_volume.rs
+++ b/examples/bounding_volume.rs
@@ -1,7 +1,9 @@
 use bevy::{
     diagnostic::{Diagnostics, FrameTimeDiagnosticsPlugin},
+    math::Vec3A,
     prelude::*,
     render::primitives::Aabb,
+    window::PresentMode,
 };
 use bevy_mod_raycast::{
     DefaultPluginState, DefaultRaycastingPlugin, RayCastMesh, RayCastMethod, RayCastSource,
@@ -15,7 +17,7 @@ use bevy_mod_raycast::{
 fn main() {
     App::new()
         .insert_resource(WindowDescriptor {
-            vsync: false, // We'll turn off vsync for this example, as it's a source of input lag.
+            present_mode: PresentMode::Immediate, // We'll turn off vsync for this example, as it's a source of input lag.
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)
@@ -201,7 +203,7 @@ fn manage_aabb(
             if enabled.0 {
                 commands.entity(entity).remove::<Aabb>();
             } else {
-                aabb.half_extents = Vec3::ONE * f32::MAX;
+                aabb.half_extents = Vec3A::ONE * f32::MAX;
             }
         }
     }

--- a/examples/mouse_picking.rs
+++ b/examples/mouse_picking.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{prelude::*, window::PresentMode};
 use bevy_mod_raycast::{
     DefaultPluginState, DefaultRaycastingPlugin, RayCastMesh, RayCastMethod, RayCastSource,
     RaycastSystem,
@@ -11,7 +11,7 @@ use bevy_mod_raycast::{
 fn main() {
     App::new()
         .insert_resource(WindowDescriptor {
-            vsync: false, // We'll turn off vsync for this example, as it's a source of input lag.
+            present_mode: PresentMode::Immediate, // We'll turn off vsync for this example, as it's a source of input lag.
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)

--- a/examples/ray_intersection_over_mesh.rs
+++ b/examples/ray_intersection_over_mesh.rs
@@ -1,6 +1,6 @@
 use std::f32::consts::FRAC_PI_2;
 
-use bevy::prelude::*;
+use bevy::{prelude::*, window::PresentMode};
 use bevy_mod_raycast::{
     ray_intersection_over_mesh, DefaultPluginState, DefaultRaycastingPlugin, Ray3d, RayCastMesh,
     RayCastMethod, RayCastSource, RaycastSystem,
@@ -15,7 +15,7 @@ use bevy_mod_raycast::{
 fn main() {
     App::new()
         .insert_resource(WindowDescriptor {
-            vsync: false, // Disabled for this demo to remove vsync as a source of input latency
+            present_mode: PresentMode::Immediate, // Disabled for this demo to remove vsync as a source of input latency
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)

--- a/examples/simplified_mesh.rs
+++ b/examples/simplified_mesh.rs
@@ -1,6 +1,7 @@
 use bevy::{
     diagnostic::{Diagnostics, FrameTimeDiagnosticsPlugin},
     prelude::*,
+    window::PresentMode,
 };
 use bevy_mod_raycast::{
     DefaultPluginState, DefaultRaycastingPlugin, RayCastMesh, RayCastMethod, RayCastSource,
@@ -14,7 +15,7 @@ use bevy_mod_raycast::{
 fn main() {
     App::new()
         .insert_resource(WindowDescriptor {
-            vsync: false, // We'll turn off vsync for this example, as it's a source of input lag.
+            present_mode: PresentMode::Immediate, // We'll turn off vsync for this example, as it's a source of input lag.
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -153,8 +153,8 @@ pub mod rays {
             // Check if the ray intersects the mesh's AABB. It's useful to work in model space because
             // we can do an AABB intersection test, instead of an OBB intersection test.
 
-            let t_0: Vec3A = (Vec3A::from(aabb.min()) - ray_origin) / ray_dir;
-            let t_1: Vec3A = (Vec3A::from(aabb.max()) - ray_origin) / ray_dir;
+            let t_0: Vec3A = (aabb.min() - ray_origin) / ray_dir;
+            let t_1: Vec3A = (aabb.max() - ray_origin) / ray_dir;
             let t_min: Vec3A = t_0.min(t_1);
             let t_max: Vec3A = t_0.max(t_1);
 

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -109,18 +109,21 @@ pub mod rays {
         pub fn from_screenspace(
             cursor_pos_screen: Vec2,
             windows: &Res<Windows>,
+            images: &Res<Assets<Image>>,
             camera: &Camera,
             camera_transform: &GlobalTransform,
         ) -> Option<Self> {
             let view = camera_transform.compute_matrix();
-            let window = match windows.get(camera.window) {
-                Some(window) => window,
+            let screen_size = match camera.target.get_logical_size(windows, images) {
+                Some(s) => s,
                 None => {
-                    error!("WindowId {} does not exist", camera.window);
+                    error!(
+                        "Unable to get screen size for RenderTarget {:?}",
+                        camera.target
+                    );
                     return None;
                 }
             };
-            let screen_size = Vec2::from([window.width() as f32, window.height() as f32]);
             let projection = camera.projection_matrix;
 
             // 2D Normalized device coordinate cursor position from (-1, -1) to (1, 1)


### PR DESCRIPTION
The biggest change is that the camera no longer references a window directly, but instead a RenderTarget. This new class has methods that directly support getting the window size.