### PR TITLE
Intersection component refactor

### DIFF
--- a/examples/bounding_volume.rs
+++ b/examples/bounding_volume.rs
@@ -10,7 +10,7 @@ use bevy_mod_raycast::{
     RaycastSystem,
 };
 
-// This example will show you how to setup bounding volume to optimise when raycasting over a
+// This example will show you how to setup bounding volume to optimize when raycasting over a
 // scene with many meshes. The bounding volume will be used to check faster for which mesh
 // to actually raycast on.
 

--- a/examples/bounding_volume.rs
+++ b/examples/bounding_volume.rs
@@ -17,7 +17,7 @@ use bevy_mod_raycast::{
 fn main() {
     App::new()
         .insert_resource(WindowDescriptor {
-            present_mode: PresentMode::Immediate, // We'll turn off vsync for this example, as it's a source of input lag.
+            present_mode: PresentMode::Immediate, // Reduces input lag.
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)
@@ -28,7 +28,7 @@ fn main() {
         // the positions of your meshes have been updated in the UPDATE stage.
         .add_system_to_stage(
             CoreStage::PreUpdate,
-            update_raycast_with_cursor.before(RaycastSystem::BuildRays),
+            update_raycast_with_cursor.before(RaycastSystem::BuildRays::<MyRaycastSet>),
         )
         .add_startup_system(setup_scene)
         .add_startup_system(setup_ui)
@@ -78,7 +78,7 @@ fn setup_scene(
     let mesh = asset_server.load("models/monkey/Monkey.gltf#Mesh0/Primitive0");
     let material = materials.add(Color::rgb(1.0, 1.0, 1.0).into());
     // Spawn multiple mesh to raycast on
-    let n = 10;
+    let n = 8;
     for i in -n..=n {
         for j in -n..=n {
             for k in -n..=n {

--- a/examples/mouse_picking.rs
+++ b/examples/mouse_picking.rs
@@ -11,7 +11,7 @@ use bevy_mod_raycast::{
 fn main() {
     App::new()
         .insert_resource(WindowDescriptor {
-            present_mode: PresentMode::Immediate, // We'll turn off vsync for this example, as it's a source of input lag.
+            present_mode: PresentMode::Immediate, // Reduces input lag.
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)
@@ -27,7 +27,7 @@ fn main() {
         // order your systems with the ones provided by the raycasting plugin.
         .add_system_to_stage(
             CoreStage::PreUpdate,
-            update_raycast_with_cursor.before(RaycastSystem::BuildRays),
+            update_raycast_with_cursor.before(RaycastSystem::BuildRays::<MyRaycastSet>),
         )
         .add_startup_system(setup)
         .run();

--- a/examples/ray_intersection_over_mesh.rs
+++ b/examples/ray_intersection_over_mesh.rs
@@ -15,7 +15,7 @@ use bevy_mod_raycast::{
 fn main() {
     App::new()
         .insert_resource(WindowDescriptor {
-            present_mode: PresentMode::Immediate, // Disabled for this demo to remove vsync as a source of input latency
+            present_mode: PresentMode::Immediate, // Reduces input latency
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)
@@ -24,7 +24,7 @@ fn main() {
         .add_startup_system(setup_ui)
         .add_system_to_stage(
             CoreStage::PreUpdate,
-            update_raycast_with_cursor.before(RaycastSystem::BuildRays),
+            update_raycast_with_cursor.before(RaycastSystem::BuildRays::<Ground>),
         )
         .add_system(check_path)
         .add_system(move_origin)
@@ -55,7 +55,7 @@ fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
             text: Text {
                 sections: vec![
                     TextSection {
-                        value: "Path between sphere and mouse cursor: ".to_string(),
+                        value: "Path between shooter and mouse cursor: ".to_string(),
                         style: TextStyle {
                             font: font.clone(),
                             font_size: 30.0,
@@ -84,9 +84,13 @@ struct PathStatus;
 // Marker struct for the ground, used to get cursor position
 #[derive(Component)]
 struct Ground;
-// Marker struct for the path origin, shown by a yellow sphere
+// Marker struct for the path origin, shown by a cyan sphere
 #[derive(Component)]
 struct PathOrigin;
+
+// Marker struct for the path pointer, shown by a cyan box
+#[derive(Component)]
+struct PathPointer;
 // Marker struct for obstacles
 #[derive(Component)]
 struct PathObstacle;
@@ -113,28 +117,31 @@ fn setup(
     commands
         .spawn_bundle(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Plane { size: 500.0 })),
-            material: materials.add(Color::rgb(0.0, 1.0, 1.0).into()),
+            material: materials.add(Color::DARK_GRAY.into()),
             ..Default::default()
         })
         .insert(RayCastMesh::<Ground>::default());
 
-    // Spawn an obstacle
-    commands
-        .spawn_bundle(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube::default())),
-            material: materials.add(Color::rgb(1.0, 0.0, 1.0).into()),
-            ..Default::default()
-        })
-        .insert(PathObstacle);
-
+    // Spawn obstacles
+    for x in -2..=2 {
+        for z in -2..=2 {
+            commands
+                .spawn_bundle(PbrBundle {
+                    mesh: meshes.add(Mesh::from(shape::Cube::default())),
+                    material: materials.add(Color::BLACK.into()),
+                    transform: Transform::from_xyz(x as f32 * 4.0, 0.0, z as f32 * 4.0),
+                    ..Default::default()
+                })
+                .insert(PathObstacle);
+        }
+    }
     // Spawn the path origin
     commands
         .spawn_bundle(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Icosphere::default())),
-            material: materials.add(Color::rgb(1.0, 1.0, 0.0).into()),
+            mesh: meshes.add(Mesh::from(shape::Cube::new(0.5))),
+            material: materials.add(Color::CYAN.into()),
             transform: Transform {
-                translation: Vec3::new(-5.0, 0.0, 0.0),
-                scale: Vec3::splat(0.2),
+                translation: Vec3::new(-6.0, 0.0, -2.0),
                 ..Default::default()
             },
             ..Default::default()
@@ -143,18 +150,27 @@ fn setup(
         .with_children(|from| {
             // Spawn a visual indicator for the path direction
             from.spawn_bundle(PbrBundle {
-                mesh: meshes.add(Mesh::from(shape::Box::new(5.0, 0.5, 0.5))),
-                material: materials.add(Color::rgb(1.0, 1.0, 0.0).into()),
-                transform: Transform::from_translation(Vec3::new(2.5, 0.0, 0.0)),
+                mesh: meshes.add(Mesh::from(shape::Box::default())),
+                material: materials.add(StandardMaterial {
+                    unlit: true,
+                    base_color: Color::RED,
+                    ..Default::default()
+                }),
+                transform: Transform::from_scale(Vec3::ZERO),
                 ..Default::default()
-            });
+            })
+            .insert(PathPointer);
         });
 
     // Spawn the intersection point, invisible by default until there is an intersection
     commands
         .spawn_bundle(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Icosphere::default())),
-            material: materials.add(Color::rgb(1.0, 0.0, 0.0).into()),
+            material: materials.add(StandardMaterial {
+                unlit: true,
+                base_color: Color::RED,
+                ..Default::default()
+            }),
             transform: Transform::from_scale(Vec3::splat(0.1)),
             visibility: Visibility {
                 is_visible: false,
@@ -164,9 +180,14 @@ fn setup(
         })
         .insert(PathObstaclePoint);
 
-    commands.spawn_bundle(PointLightBundle {
-        transform: Transform::from_translation(Vec3::new(4.0, 8.0, 4.0)),
+    commands.spawn_bundle(DirectionalLightBundle {
+        transform: Transform::from_translation(Vec3::new(4.0, 8.0, 4.0))
+            .looking_at(Vec3::ZERO, Vec3::Y),
         ..Default::default()
+    });
+    commands.insert_resource(AmbientLight {
+        color: Color::WHITE,
+        brightness: 0.2,
     });
 }
 
@@ -201,6 +222,14 @@ fn check_path(
             Without<PathObstaclePoint>,
         ),
     >,
+    mut pointer: Query<
+        &mut Transform,
+        (
+            With<PathPointer>,
+            Without<PathOrigin>,
+            Without<PathObstacle>,
+        ),
+    >,
     to: Query<&RayCastSource<Ground>>,
     obstacles: Query<(&Handle<Mesh>, &Transform), With<PathObstacle>>,
     meshes: Res<Assets<Mesh>>,
@@ -211,57 +240,65 @@ fn check_path(
             With<PathObstaclePoint>,
             Without<PathObstacle>,
             Without<PathOrigin>,
+            Without<PathPointer>,
         ),
     >,
 ) {
     if let Ok(mut origin_transform) = from.get_single_mut() {
-        if let Ok(raycast_source) = to.get_single() {
-            if let Some(top_intersection) = raycast_source.intersect_top() {
-                let from = origin_transform.translation;
-                let to = top_intersection.1.position();
-                let ray_direction = (to - from).normalize();
+        let raycast_source = to.single();
+        let mut pointer = pointer.single_mut();
+        if let Some(top_intersection) = raycast_source.intersect_top() {
+            let from = origin_transform.translation;
+            let to = top_intersection.1.position();
+            let ray_direction = (to - from).normalize();
 
-                // Rotate the direction indicator
-                if Vec3::Z.angle_between(ray_direction) > FRAC_PI_2 {
-                    origin_transform.rotation =
-                        Quat::from_rotation_y(Vec3::X.angle_between(ray_direction));
-                } else {
-                    origin_transform.rotation =
-                        Quat::from_rotation_y(-Vec3::X.angle_between(ray_direction));
-                }
+            // Rotate the direction indicator
+            if Vec3::Z.angle_between(ray_direction) > FRAC_PI_2 {
+                origin_transform.rotation =
+                    Quat::from_rotation_y(Vec3::X.angle_between(ray_direction));
+            } else {
+                origin_transform.rotation =
+                    Quat::from_rotation_y(-Vec3::X.angle_between(ray_direction));
+            }
 
-                let ray = Ray3d::new(from, ray_direction);
-                if let Ok(mut text) = status_query.get_single_mut() {
-                    if let Ok((mut intersection_transform, mut visible)) =
-                        intersection_point.get_single_mut()
-                    {
-                        // Set everything as OK in case there are no obstacle in path
-                        text.sections[1].value = "Direct!".to_string();
-                        text.sections[1].style.color = Color::GREEN;
-                        visible.is_visible = false;
+            let ray = Ray3d::new(from, ray_direction);
+            if let Ok(mut text) = status_query.get_single_mut() {
+                if let Ok((mut intersection_transform, mut visible)) =
+                    intersection_point.get_single_mut()
+                {
+                    // Set everything as OK in case there are no obstacle in path
+                    text.sections[1].value = "Direct!".to_string();
+                    text.sections[1].style.color = Color::GREEN;
+                    visible.is_visible = false;
 
-                        // Check for an obstacle on path
-                        for (mesh_handle, transform) in obstacles.iter() {
-                            if let Some(mesh) = meshes.get(mesh_handle) {
-                                let mesh_to_world = transform.compute_matrix();
+                    let mut closest_hit = f32::MAX;
 
-                                // Check for intersection with this obstacle
-                                if let Some(intersection) =
-                                    ray_intersection_over_mesh(mesh, &mesh_to_world, &ray)
-                                {
-                                    // There was an intersection, check if it is before the cursor
-                                    // on the ray
-                                    if intersection.distance() < from.distance(to) {
-                                        text.sections[1].value = "Obstructed!".to_string();
-                                        text.sections[1].style.color = Color::RED;
-                                        intersection_transform.translation =
-                                            intersection.position();
-                                        visible.is_visible = true;
-                                    }
+                    // Check for an obstacle on path
+                    for (mesh_handle, transform) in obstacles.iter() {
+                        if let Some(mesh) = meshes.get(mesh_handle) {
+                            let mesh_to_world = transform.compute_matrix();
+
+                            // Check for intersection with this obstacle
+                            if let Some(intersection) =
+                                ray_intersection_over_mesh(mesh, &mesh_to_world, &ray)
+                            {
+                                // There was an intersection, check if it is before the cursor
+                                // on the ray
+                                let hit_distance = intersection.distance();
+                                let cursor_distance = from.distance(to);
+                                if hit_distance < cursor_distance && hit_distance < closest_hit {
+                                    text.sections[1].value = "Obstructed!".to_string();
+                                    text.sections[1].style.color = Color::RED;
+                                    intersection_transform.translation = intersection.position();
+                                    visible.is_visible = true;
+                                    closest_hit = hit_distance;
                                 }
                             }
                         }
                     }
+
+                    pointer.scale = Vec3::new(closest_hit / 2.0, 0.05, 0.05);
+                    pointer.translation = Vec3::new(closest_hit / 2.0, 0.0, 0.0);
                 }
             }
         }

--- a/examples/simplified_mesh.rs
+++ b/examples/simplified_mesh.rs
@@ -8,7 +8,7 @@ use bevy_mod_raycast::{
     RaycastSystem, SimplifiedMesh,
 };
 
-// This example will show you how to setup simplified mesh to optimise when raycasting over a
+// This example will show you how to setup simplified mesh to optimize when raycasting over a
 // scene with a complicated mesh. The simplified mesh will be used to check faster for intersection
 // with the mesh.
 

--- a/examples/simplified_mesh.rs
+++ b/examples/simplified_mesh.rs
@@ -15,7 +15,7 @@ use bevy_mod_raycast::{
 fn main() {
     App::new()
         .insert_resource(WindowDescriptor {
-            present_mode: PresentMode::Immediate, // We'll turn off vsync for this example, as it's a source of input lag.
+            present_mode: PresentMode::Immediate, // Reduces input lag.
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)
@@ -26,7 +26,7 @@ fn main() {
         // the positions of your meshes have been updated in the UPDATE stage.
         .add_system_to_stage(
             CoreStage::PreUpdate,
-            update_raycast_with_cursor.before(RaycastSystem::BuildRays),
+            update_raycast_with_cursor.before(RaycastSystem::BuildRays::<MyRaycastSet>),
         )
         .add_startup_system(setup_scene)
         .add_startup_system(setup_ui)


### PR DESCRIPTION
Updates the `Intersection` struct to actually be used as a component.

This makes it possible to query for intersections, instead of querying pick sources, and checking `intersect_top`.