### PR TITLE
Refactor intersect_primitive API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,29 +263,7 @@ impl<T> RayCastSource<T> {
         }
     }
     pub fn intersect_primitive(&self, shape: Primitive3d) -> Option<IntersectionData> {
-        let ray = self.ray?;
-        match shape {
-            Primitive3d::Plane {
-                point: plane_origin,
-                normal: plane_normal,
-            } => {
-                // assuming vectors are all normalized
-                let denominator = ray.direction().dot(plane_normal);
-                if denominator.abs() > f32::EPSILON {
-                    let point_to_point = plane_origin - ray.origin();
-                    let intersect_dist = plane_normal.dot(point_to_point) / denominator;
-                    let intersect_position = ray.direction() * intersect_dist + ray.origin();
-                    Some(IntersectionData::new(
-                        intersect_position,
-                        plane_normal,
-                        intersect_dist,
-                        None,
-                    ))
-                } else {
-                    None
-                }
-            }
-        }
+        Some(self.ray?.intersects_primitive(shape)?.into())
     }
     /// Get a reference to the ray cast source's ray.
     pub fn ray(&self) -> Option<Ray3d> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,8 +388,7 @@ pub fn update_raycast<T: 'static>(
         ),
         With<RayCastMesh<T>>,
     >,
-    #[cfg(feature = "2d")]
-    mesh2d_query: Query<
+    #[cfg(feature = "2d")] mesh2d_query: Query<
         (
             &Mesh2dHandle,
             Option<&SimplifiedMesh>,

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -135,12 +135,12 @@ impl<T> Intersection<T> {
 /// Encapsulates Ray3D, preventing use of struct literal syntax. This allows us to guarantee that
 /// the `Ray3d` direction is normalized, because it can only be instantiated with the constructor.
 pub mod rays {
+    use super::Primitive3d;
     use bevy::{
         math::Vec3A,
         prelude::*,
         render::{camera::Camera, primitives::Aabb},
     };
-    use super::Primitive3d;
 
     pub struct PrimitiveIntersection {
         position: Vec3,


### PR DESCRIPTION
This PR is a suggestion to refactor the API for `RayCastSource::Intersect_primitive`.

I've found that I frequently have a need for calculating a ray's application with a plane in my application, and I thought it would be better if the `Ray3d` class had a convenience function for that. I noticed that `RayCastSource` has the right calculation, but the calculation really only needs the information of a `Ray3d`, it doesn't need all the information in a `RayCastSource`. So I've migrated the implementation from `RayCastSource` into `Ray3d` and redirected `RayCastSource`'s implementation to just use the `Ray3d` one.

This shouldn't break any API, it only expands the API.