### PR TITLE
`Intersection` API updates

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -39,23 +39,17 @@ pub fn update_debug_cursor<T: 'static>(
 ) {
     // Set the cursor translation to the top pick's world coordinates
     for (intersection, mut transform) in &mut cursors {
-        if let Some(new_matrix) = intersection.normal_ray() {
-            *transform = Transform::from_matrix(new_matrix.to_transform());
-        } else {
-            *transform = Transform::from_translation(Vec3::NAN);
-        }
+        *transform = Transform::from_matrix(intersection.normal_ray().to_transform());
     }
     // Spawn a new debug cursor for intersections without one
     for (entity, intersection) in &intersection_without_cursor {
-        if let Some(new_matrix) = intersection.normal_ray() {
-            spawn_cursor::<T>(
-                &mut commands,
-                entity,
-                Transform::from_matrix(new_matrix.to_transform()),
-                &mut meshes,
-                &mut materials,
-            );
-        }
+        spawn_cursor::<T>(
+            &mut commands,
+            entity,
+            Transform::from_matrix(intersection.normal_ray().to_transform()),
+            &mut meshes,
+            &mut materials,
+        );
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -530,7 +530,7 @@ pub fn update_intersections<T: 'static>(
     for (entity, new_intersect) in new_intersections.into_iter() {
         match old_intersections.get_mut(entity) {
             // Update Intersection components that already exist
-            Ok((_, mut old_intersect)) => old_intersect.data = Some(new_intersect.to_owned()),
+            Ok((_, mut old_intersect)) => old_intersect.data = new_intersect.to_owned(),
             // Add Intersection components to entities that did not have them already
             Err(_) => {
                 commands

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -536,12 +536,18 @@ pub fn update_intersections<T: 'static>(
             commands.entity(entity).remove::<Intersection<T>>();
         }
     }
+
     for (entity, new_intersect) in new_intersections.into_iter() {
         match old_intersections.get_mut(entity) {
-            // Update Intersection components that already exist
-            Ok((_, mut old_intersect)) => old_intersect.data = new_intersect.to_owned(),
-            // Add Intersection components to entities that did not have them already
+            Ok((_, mut old_intersect)) => {
+                // Update Intersection components that already exist.
+                // Only trigger change detection if the value has really changed
+                if &old_intersect.data != new_intersect {
+                    old_intersect.data = new_intersect.to_owned();
+                }
+            }
             Err(_) => {
+                // Add Intersection components to entities that did not have them already
                 commands
                     .entity(entity)
                     .insert(Intersection::<T>::new(new_intersect.to_owned()));

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -10,7 +10,7 @@ pub enum Primitive3d {
     Plane { point: Vec3, normal: Vec3 },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct IntersectionData {
     position: Vec3,
     normal: Vec3,

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -73,21 +73,17 @@ impl IntersectionData {
 /// `Intersection` component added to it, with the intersection data.
 #[derive(Component)]
 pub struct Intersection<T> {
-    pub(crate) data: Option<IntersectionData>,
+    pub(crate) data: IntersectionData,
     _phantom: PhantomData<fn(T) -> T>,
 }
 impl<T> std::fmt::Debug for Intersection<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.data {
-            Some(data) => f
-                .debug_struct("Intersection")
-                .field("position", &data.position)
-                .field("normal", &data.normal)
-                .field("distance", &data.distance)
-                .field("triangle", &data.triangle)
-                .finish(),
-            None => write!(f, "None"),
-        }
+        f.debug_struct("Intersection")
+            .field("position", &self.data.position)
+            .field("normal", &self.data.normal)
+            .field("distance", &self.data.distance)
+            .field("triangle", &self.data.triangle)
+            .finish()
     }
 }
 impl<T> Clone for Intersection<T> {
@@ -101,36 +97,28 @@ impl<T> Clone for Intersection<T> {
 impl<T> Intersection<T> {
     pub fn new(data: IntersectionData) -> Self {
         Intersection {
-            data: Some(data),
+            data,
             _phantom: PhantomData,
         }
     }
     /// Position vector describing the intersection position.
-    pub fn position(&self) -> Option<&Vec3> {
-        if let Some(data) = &self.data {
-            Some(&data.position)
-        } else {
-            None
-        }
+    pub fn position(&self) -> Vec3 {
+        self.data.position
     }
     /// Unit vector describing the normal of the intersected triangle.
-    pub fn normal(&self) -> Option<Vec3> {
-        self.data().map(|data| data.normal)
+    pub fn normal(&self) -> Vec3 {
+        self.data.normal
     }
-    pub fn normal_ray(&self) -> Option<Ray3d> {
-        self.data()
-            .map(|data| Ray3d::new(data.position, data.normal))
+    pub fn normal_ray(&self) -> Ray3d {
+        Ray3d::new(self.data.position, self.data.normal)
     }
     /// Distance from the picking source to the entity.
-    pub fn distance(&self) -> Option<f32> {
-        self.data().map(|data| data.distance)
+    pub fn distance(&self) -> f32 {
+        self.data.distance
     }
     /// Triangle that was intersected with in World coordinates
     pub fn world_triangle(&self) -> Option<Triangle> {
-        self.data().and_then(|data| data.triangle)
-    }
-    fn data(&self) -> Option<&IntersectionData> {
-        self.data.as_ref()
+        self.data.triangle
     }
 }
 


### PR DESCRIPTION
This adds a few features and simplifies some of the mod's API.

- Places `Intersection` components on the entities that the ray intersects with.
  - This now requires that commands get run before intersection information is valid, but this was already potentially the case if a new `Intersection` needed to be created.
  - The same component is re-used if an `Intersection` remains on the same entity, and it is only updated if the data actually changes, allowing `Added<>` and `Changed<>` to work intuitively. 
- Since global `Intersection`s are no longer used, `Interesection.data` no longer needs to be `Optional` for re-use optimization.
- Allows for particular `RaycastSource`s to be disabled.
  - If disabled, its ray is set to `None`, meaning that raycasting will not be done, and any `Intersection`s will be cleared.