### PR TITLE
fix to_aligned_transform for colinear up and normal vectors

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -218,14 +218,7 @@ pub mod rays {
         pub fn to_aligned_transform(self, up: Vec3) -> Mat4 {
             let position = self.origin();
             let normal = self.direction();
-            let axis = up.cross(normal).normalize();
-            let angle = up.dot(normal).acos();
-            let epsilon = f32::EPSILON;
-            let new_rotation = if angle.abs() > epsilon {
-                Quat::from_axis_angle(axis, angle)
-            } else {
-                Quat::default()
-            };
+            let new_rotation = Quat::from_rotation_arc(up, normal);
             Mat4::from_rotation_translation(new_rotation, position)
         }
 


### PR DESCRIPTION
I believe this:
 - fixes #5,
 - allows to run with `debug-glam-assert` (otherwise it would assert on `up.cross(normal).normalize()`).

Please note I'm a dunce when it comes to maths/3D but that seems simple enough.

Before: ![before](https://user-images.githubusercontent.com/3048933/230126938-c74b2795-b5bb-4a84-86f7-fcaaf8ec40da.png)
After: ![after](https://user-images.githubusercontent.com/3048933/230127028-d6a62dc8-2b1d-4544-9ae6-6f145a89dc1a.png)

