### PR TITLE
Ray3d::from_screenspace() implementation from Camera.viewport_to_world()

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -242,23 +242,10 @@ pub mod rays {
             camera: &Camera,
             camera_transform: &GlobalTransform,
         ) -> Option<Self> {
-            let view = camera_transform.compute_matrix();
-
-            let (viewport_min, viewport_max) = camera.logical_viewport_rect()?;
-            let screen_size = camera.logical_target_size()?;
-            let viewport_size = viewport_max - viewport_min;
-            let adj_cursor_pos =
-                cursor_pos_screen - Vec2::new(viewport_min.x, screen_size.y - viewport_max.y);
-
-            let projection = camera.projection_matrix();
-            let far_ndc = projection.project_point3(Vec3::NEG_Z).z;
-            let near_ndc = projection.project_point3(Vec3::Z).z;
-            let cursor_ndc = (adj_cursor_pos / viewport_size) * 2.0 - Vec2::ONE;
-            let ndc_to_world: Mat4 = view * projection.inverse();
-            let near = ndc_to_world.project_point3(cursor_ndc.extend(near_ndc));
-            let far = ndc_to_world.project_point3(cursor_ndc.extend(far_ndc));
-            let ray_direction = far - near;
-            Some(Ray3d::new(near, ray_direction))
+            match camera.viewport_to_world(camera_transform, cursor_pos_screen) {
+                Some(r) => Some(Ray3d::new(r.origin, r.direction)),
+                None => None,
+            }
         }
 
         /// Checks if the ray intersects with an AABB of a mesh.


### PR DESCRIPTION
## Summary

https://github.com/bevyengine/bevy/pull/8306 introduces consistent coordinates for every entity without `.y` flipping. The changes are not rolled out yet, but current `main` of `bevy_mod_raycast` is not working well with `bevy`'s `main`. In attempt to fix this, I found a simple but questionable solution:

https://github.com/aevyrie/bevy_mod_raycast/blob/bd84951952f58a36c8144725f6539e7b3f60ed0f/src/primitives.rs#L240-L262

is equal to

https://github.com/bevyengine/bevy/blob/585baf0a66b855cef1f0568a4af44b666cfee076/crates/bevy_render/src/camera/camera.rs#L250-L270

## Solution

It seems that there's no reason not to utilize `Camera::viewport_to_world()` as it's available since https://github.com/bevyengine/bevy/commit/37860a09de897218e6698eaf16dcc7836525a9fb from `v0.9.0`. I propose to utilize `Camera.viewport_to_world()` under the hood of `Ray3d::from_screenspace()` as their purposes seems identical. Changes doesn't seem to break any `examples` functionality on my end