### PR TITLE
Expose mesh indices in intersection data

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -10,7 +10,7 @@ pub enum Primitive3d {
     Plane { point: Vec3, normal: Vec3 },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct IntersectionData {
     position: Vec3,
     normal: Vec3,
@@ -334,31 +334,16 @@ pub struct Triangle {
     pub v0: Vec3A,
     pub v1: Vec3A,
     pub v2: Vec3A,
+    pub indices: Option<UVec3>,
 }
-impl From<(Vec3A, Vec3A, Vec3A)> for Triangle {
-    fn from(vertices: (Vec3A, Vec3A, Vec3A)) -> Self {
-        Triangle {
-            v0: vertices.0,
-            v1: vertices.1,
-            v2: vertices.2,
-        }
-    }
-}
-impl From<Vec<Vec3A>> for Triangle {
-    fn from(vertices: Vec<Vec3A>) -> Self {
-        Triangle {
-            v0: *vertices.get(0).unwrap(),
-            v1: *vertices.get(1).unwrap(),
-            v2: *vertices.get(2).unwrap(),
-        }
-    }
-}
-impl From<[Vec3A; 3]> for Triangle {
-    fn from(vertices: [Vec3A; 3]) -> Self {
-        Triangle {
-            v0: vertices[0],
-            v1: vertices[1],
-            v2: vertices[2],
+
+impl Triangle {
+    pub fn new(v0: Vec3A, v1: Vec3A, v2: Vec3A, indices: Option<UVec3>) -> Self {
+        Self {
+            v0,
+            v1,
+            v2,
+            indices,
         }
     }
 }

--- a/src/raycast.rs
+++ b/src/raycast.rs
@@ -93,7 +93,7 @@ pub fn raycast_moller_trumbore(
 
 #[cfg(test)]
 mod tests {
-    use bevy::math::Vec3;
+    use bevy::math::{UVec3, Vec3};
 
     use super::*;
 
@@ -101,10 +101,11 @@ mod tests {
     const V0: [f32; 3] = [1.0, -1.0, 2.0];
     const V1: [f32; 3] = [1.0, 2.0, -1.0];
     const V2: [f32; 3] = [1.0, -1.0, -1.0];
+    const INDICES: UVec3 = UVec3::new(0, 1, 2);
 
     #[test]
     fn raycast_triangle_mt() {
-        let triangle = Triangle::from([V0.into(), V1.into(), V2.into()]);
+        let triangle = Triangle::new(V0.into(), V1.into(), V2.into(), Some(INDICES));
         let ray = Ray3d::new(Vec3::ZERO, Vec3::X);
         let result = ray_triangle_intersection(&ray, &triangle, Backfaces::Include);
         assert!(result.unwrap().distance - 1.0 <= f32::EPSILON);
@@ -112,7 +113,7 @@ mod tests {
 
     #[test]
     fn raycast_triangle_mt_culling() {
-        let triangle = Triangle::from([V2.into(), V1.into(), V0.into()]);
+        let triangle = Triangle::new(V2.into(), V1.into(), V0.into(), Some(INDICES));
         let ray = Ray3d::new(Vec3::ZERO, Vec3::X);
         let result = ray_triangle_intersection(&ray, &triangle, Backfaces::Cull);
         assert!(result.is_none());


### PR DESCRIPTION
Note: I also ran `cargo fmt`, which reformatted `src/primitives.rs` since it used carriage returns.