### PR TITLE
Bevy 0.11.0-dev compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ categories = ["game-engines", "rendering"]
 resolver = "2"
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.11.0-dev", default-features = false, features = [
     "bevy_render",
     "bevy_asset",
 ] }
 
 [dev-dependencies]
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.11.0-dev", default-features = false, features = [
     "bevy_pbr",
     "bevy_winit",
     "bevy_ui",

--- a/examples/bounding_volume.rs
+++ b/examples/bounding_volume.rs
@@ -29,16 +29,15 @@ fn main() {
         // You will need to pay attention to what order you add systems! Putting them in the wrong
         // order can result in multiple frames of latency. Ray casting should probably happen after
         // the positions of your meshes have been updated in the UPDATE stage.
-        .add_system(
-            update_raycast_with_cursor
-                .before(RaycastSystem::BuildRays::<MyRaycastSet>)
-                .in_base_set(CoreSet::First),
+        .add_systems(
+            First,
+            update_raycast_with_cursor.before(RaycastSystem::BuildRays::<MyRaycastSet>),
         )
-        .add_startup_system(setup_scene)
-        .add_startup_system(setup_ui)
-        .add_system(update_fps)
-        .add_system(make_scene_pickable)
-        .add_system(manage_aabb.in_base_set(CoreSet::First))
+        .add_systems(Startup, setup_scene)
+        .add_systems(Startup, setup_ui)
+        .add_systems(Update, update_fps)
+        .add_systems(Update, make_scene_pickable)
+        .add_systems(First, manage_aabb)
         .run();
 }
 

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -13,9 +13,9 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(DefaultRaycastingPlugin::<MyRaycastSet>::default())
-        .add_startup_system(setup)
-        .add_system(rotator)
-        .add_system(intersection)
+        .add_systems(Startup, setup)
+        .add_systems(Update, rotator)
+        .add_systems(Update, intersection)
         .run();
 }
 

--- a/examples/mouse_picking.rs
+++ b/examples/mouse_picking.rs
@@ -28,12 +28,11 @@ fn main() {
         // start of the frame. For example, we want to be sure this system runs before we construct
         // any rays, hence the ".before(...)". You can use these provided RaycastSystem labels to
         // order your systems with the ones provided by the raycasting plugin.
-        .add_system(
-            update_raycast_with_cursor
-                .in_base_set(CoreSet::First)
-                .before(RaycastSystem::BuildRays::<MyRaycastSet>),
+        .add_systems(
+            First,
+            update_raycast_with_cursor.before(RaycastSystem::BuildRays::<MyRaycastSet>),
         )
-        .add_startup_system(setup)
+        .add_systems(Startup, setup)
         .run();
 }
 

--- a/examples/mouse_picking_2d.rs
+++ b/examples/mouse_picking_2d.rs
@@ -7,13 +7,12 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(DefaultRaycastingPlugin::<MyRaycastSet>::default())
-        .add_system(
-            update_raycast_with_cursor
-                .in_base_set(CoreSet::First)
-                .before(RaycastSystem::BuildRays::<MyRaycastSet>),
+        .add_systems(
+            First,
+            update_raycast_with_cursor.before(RaycastSystem::BuildRays::<MyRaycastSet>),
         )
-        .add_system(intersection)
-        .add_startup_system(setup)
+        .add_systems(Update, intersection)
+        .add_systems(Startup, setup)
         .run();
 }
 

--- a/examples/ray_intersection_over_mesh.rs
+++ b/examples/ray_intersection_over_mesh.rs
@@ -23,15 +23,14 @@ fn main() {
             ..default()
         }))
         .add_plugin(DefaultRaycastingPlugin::<Ground>::default())
-        .add_startup_system(setup)
-        .add_startup_system(setup_ui)
-        .add_system(
-            update_raycast_with_cursor
-                .before(RaycastSystem::BuildRays::<Ground>)
-                .in_base_set(CoreSet::First),
+        .add_systems(Startup, setup)
+        .add_systems(Startup, setup_ui)
+        .add_systems(
+            First,
+            update_raycast_with_cursor.before(RaycastSystem::BuildRays::<Ground>),
         )
-        .add_system(check_path)
-        .add_system(move_origin)
+        .add_systems(Update, check_path)
+        .add_systems(Update, move_origin)
         .run();
 }
 

--- a/examples/simplified_mesh.rs
+++ b/examples/simplified_mesh.rs
@@ -26,15 +26,14 @@ fn main() {
         // You will need to pay attention to what order you add systems! Putting them in the wrong
         // order can result in multiple frames of latency. Ray casting should probably happen after
         // the positions of your meshes have been updated in the UPDATE stage.
-        .add_system(
-            update_raycast_with_cursor_position
-                .before(RaycastSystem::BuildRays::<MyRaycastSet>)
-                .in_base_set(CoreSet::First),
+        .add_systems(
+            First,
+            update_raycast_with_cursor_position.before(RaycastSystem::BuildRays::<MyRaycastSet>),
         )
-        .add_startup_system(setup_scene)
-        .add_startup_system(setup_ui)
-        .add_system(update_fps)
-        .add_system(manage_simplified_mesh)
+        .add_systems(Startup, setup_scene)
+        .add_systems(Startup, setup_ui)
+        .add_systems(Update, update_fps)
+        .add_systems(Update, manage_simplified_mesh)
         .run();
 }
 

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -244,7 +244,10 @@ pub mod rays {
         ) -> Option<Self> {
             let view = camera_transform.compute_matrix();
 
-            let (viewport_min, viewport_max) = camera.logical_viewport_rect()?;
+            let Rect {
+                min: viewport_min,
+                max: viewport_max,
+            } = camera.logical_viewport_rect()?;
             let screen_size = camera.logical_target_size()?;
             let viewport_size = viewport_max - viewport_min;
             let adj_cursor_pos =

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -250,8 +250,10 @@ pub mod rays {
             } = camera.logical_viewport_rect()?;
             let screen_size = camera.logical_target_size()?;
             let viewport_size = viewport_max - viewport_min;
-            let adj_cursor_pos =
-                cursor_pos_screen - Vec2::new(viewport_min.x, screen_size.y - viewport_max.y);
+            let cursor_pos_screen_flipped =
+                Vec2::new(cursor_pos_screen.x, screen_size.y - cursor_pos_screen.y);
+            let adj_cursor_pos = cursor_pos_screen_flipped
+                - Vec2::new(viewport_min.x, screen_size.y - viewport_max.y);
 
             let projection = camera.projection_matrix();
             let far_ndc = projection.project_point3(Vec3::NEG_Z).z;


### PR DESCRIPTION
Hey 👋 

I needed picking for a project targeting the latest current `main` bevy branch, (v0.11.0-dev) so I've updated this crate (and also `bevy_mod_picking`) to work under it. Here are the breaking changes I had to account for:

- Removal of base sets
- Changes to `.add_systems()`
- Y coordinate of cursor position is no longer flipped

It's likely there will be more breaking changes before the 0.11.0 release; I'll try to keep this PR up-to-date.

## Related PRs

Picking PR: https://github.com/aevyrie/bevy_mod_picking/pull/200