### PR TITLE
Attach intersection component directly to intersecting entities

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -687,17 +687,17 @@ pub fn ray_mesh_intersection(
             }
         }
     } else {
-        for vertex in vertex_positions.chunks(3) {
+        for i in (0..vertex_positions.len()).step_by(3) {
             let tri_vertex_positions = [
-                Vec3A::from(vertex[0]),
-                Vec3A::from(vertex[1]),
-                Vec3A::from(vertex[2]),
+                Vec3A::from(vertex_positions[i]),
+                Vec3A::from(vertex_positions[i + 1]),
+                Vec3A::from(vertex_positions[i + 2]),
             ];
             let tri_normals = vertex_normals.map(|normals| {
                 [
-                    Vec3A::from(normals[0]),
-                    Vec3A::from(normals[1]),
-                    Vec3A::from(normals[2]),
+                    Vec3A::from(normals[i]),
+                    Vec3A::from(normals[i + 1]),
+                    Vec3A::from(normals[i + 2]),
                 ]
             });
             let intersection = triangle_intersection(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -500,8 +500,11 @@ pub fn update_intersections<T: Reflect + Clone + 'static>(
     mut query: Query<(Entity, &mut Intersection<T>)>,
     sources: Query<&RaycastSource<T>>,
 ) {
+    // Collect all entities which currently have an intersection component
     let mut entities: HashMap<Entity, Mut<Intersection<T>>> = query.iter_mut().collect();
 
+    // Iterate over entities which should have an intersection component
+    // and test which currently have one.
     for (e, i) in sources
         .iter()
         .filter_map(|source| source.get_nearest_intersection())
@@ -518,6 +521,7 @@ pub fn update_intersections<T: Reflect + Clone + 'static>(
         }
     }
 
+    // The remaining entities in the map no longer have an intersection
     for (e, _) in entities {
         // Intersection removed
         commands.entity(e).remove::<Intersection<T>>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -509,6 +509,7 @@ pub fn update_intersections<T: Reflect + Clone + 'static>(
         if let Some(intersection) = entities.get_mut(&e) {
             // Intersection changed
             intersection.data = Some(i.to_owned());
+            entities.remove(&e);
         } else {
             // Intersection added
             commands


### PR DESCRIPTION
Before, the `Intersection` component was added to a newly spawned empty entity.