### PR TITLE
Ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ Cargo.lock
 *.iml
 .idea/
 trace*.json
+.DS_Store
+


### PR DESCRIPTION
MacOS annoyingly tends to create these hidden folders.