### PR TITLE
Update to Bevy v0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ categories = ["game-engines", "rendering"]
 resolver = "2"
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.11", default-features = false, features = [
     "bevy_render",
     "bevy_asset",
 ] }
 
 [dev-dependencies]
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.11", default-features = false, features = [
     "bevy_pbr",
     "bevy_winit",
     "bevy_ui",

--- a/examples/bounding_volume.rs
+++ b/examples/bounding_volume.rs
@@ -1,5 +1,6 @@
 use bevy::{
-    diagnostic::{Diagnostics, FrameTimeDiagnosticsPlugin},
+    core_pipeline::tonemapping::Tonemapping,
+    diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin},
     math::Vec3A,
     prelude::*,
     render::primitives::Aabb,
@@ -17,28 +18,27 @@ use bevy_mod_raycast::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                present_mode: PresentMode::AutoNoVsync,
+        .add_plugins((
+            DefaultPlugins.set(WindowPlugin {
+                primary_window: Some(Window {
+                    present_mode: PresentMode::AutoNoVsync,
+                    ..default()
+                }),
                 ..default()
             }),
-            ..default()
-        }))
-        .add_plugin(FrameTimeDiagnosticsPlugin::default())
-        .add_plugin(DefaultRaycastingPlugin::<MyRaycastSet>::default())
+            FrameTimeDiagnosticsPlugin::default(),
+            DefaultRaycastingPlugin::<MyRaycastSet>::default(),
+        ))
         // You will need to pay attention to what order you add systems! Putting them in the wrong
         // order can result in multiple frames of latency. Ray casting should probably happen after
         // the positions of your meshes have been updated in the UPDATE stage.
-        .add_system(
-            update_raycast_with_cursor
-                .before(RaycastSystem::BuildRays::<MyRaycastSet>)
-                .in_base_set(CoreSet::First),
+        .add_systems(
+            First,
+            update_raycast_with_cursor.before(RaycastSystem::BuildRays::<MyRaycastSet>),
         )
-        .add_startup_system(setup_scene)
-        .add_startup_system(setup_ui)
-        .add_system(update_fps)
-        .add_system(make_scene_pickable)
-        .add_system(manage_aabb.in_base_set(CoreSet::First))
+        .add_systems(Startup, (setup_scene, setup_ui))
+        .add_systems(Update, (update_fps, make_scene_pickable))
+        .add_systems(First, manage_aabb)
         .run();
 }
 
@@ -74,7 +74,10 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
     });
 
     commands
-        .spawn(Camera3dBundle::default())
+        .spawn(Camera3dBundle {
+            tonemapping: Tonemapping::ReinhardLuminance,
+            ..default()
+        })
         .insert(RaycastSource::<MyRaycastSet>::new()); // Designate the camera as our source
 
     // Spawn multiple mesh to raycast on
@@ -219,7 +222,7 @@ fn manage_aabb(
     }
 }
 
-fn update_fps(diagnostics: Res<Diagnostics>, mut query: Query<&mut Text, With<FpsText>>) {
+fn update_fps(diagnostics: Res<DiagnosticsStore>, mut query: Query<&mut Text, With<FpsText>>) {
     for mut text in &mut query {
         if let Some(fps) = diagnostics.get(FrameTimeDiagnosticsPlugin::FPS) {
             if let Some(average) = fps.smoothed() {

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{core_pipeline::tonemapping::Tonemapping, prelude::*};
 use bevy_mod_raycast::{
     DefaultPluginState, DefaultRaycastingPlugin, Intersection, RaycastMesh, RaycastSource,
 };
@@ -11,11 +11,12 @@ use bevy_mod_raycast::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(DefaultRaycastingPlugin::<MyRaycastSet>::default())
-        .add_startup_system(setup)
-        .add_system(rotator)
-        .add_system(intersection)
+        .add_plugins((
+            DefaultPlugins,
+            DefaultRaycastingPlugin::<MyRaycastSet>::default(),
+        ))
+        .add_systems(Startup, setup)
+        .add_systems(Update, (rotator, intersection))
         .run();
 }
 
@@ -40,6 +41,7 @@ fn setup(
                 scale: 0.01,
                 ..default()
             }),
+            tonemapping: Tonemapping::ReinhardLuminance,
             ..default()
         },
         // Designate the camera as our ray casting source. Using `new_transform_empty()` means that

--- a/examples/mouse_picking.rs
+++ b/examples/mouse_picking.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, window::PresentMode};
+use bevy::{core_pipeline::tonemapping::Tonemapping, prelude::*, window::PresentMode};
 
 use bevy_mod_raycast::{
     DefaultPluginState, DefaultRaycastingPlugin, RaycastMesh, RaycastMethod, RaycastSource,
@@ -22,18 +22,17 @@ fn main() {
         // plugin. This includes building rays, casting them, and placing a debug cursor at the
         // intersection. For more advanced uses, you can compose the systems in this plugin however
         // you need. For example, you might exclude the debug cursor system.
-        .add_plugin(DefaultRaycastingPlugin::<MyRaycastSet>::default())
+        .add_plugins(DefaultRaycastingPlugin::<MyRaycastSet>::default())
         // You will need to pay attention to what order you add systems! Putting them in the wrong
         // order can result in multiple frames of latency. Ray casting should probably happen near
         // start of the frame. For example, we want to be sure this system runs before we construct
         // any rays, hence the ".before(...)". You can use these provided RaycastSystem labels to
         // order your systems with the ones provided by the raycasting plugin.
-        .add_system(
-            update_raycast_with_cursor
-                .in_base_set(CoreSet::First)
-                .before(RaycastSystem::BuildRays::<MyRaycastSet>),
+        .add_systems(
+            First,
+            update_raycast_with_cursor.before(RaycastSystem::BuildRays::<MyRaycastSet>),
         )
-        .add_startup_system(setup)
+        .add_systems(Startup, setup)
         .run();
 }
 
@@ -72,6 +71,7 @@ fn setup(
     commands
         .spawn(Camera3dBundle {
             transform: Transform::from_xyz(-2.0, 2.0, 2.0).looking_at(Vec3::ZERO, Vec3::Y),
+            tonemapping: Tonemapping::ReinhardLuminance,
             ..Default::default()
         })
         .insert(RaycastSource::<MyRaycastSet>::new()); // Designate the camera as our source

--- a/examples/mouse_picking_2d.rs
+++ b/examples/mouse_picking_2d.rs
@@ -1,19 +1,20 @@
-use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
+use bevy::{core_pipeline::tonemapping::Tonemapping, prelude::*, sprite::MaterialMesh2dBundle};
 use bevy_mod_raycast::{
     DefaultRaycastingPlugin, Intersection, RaycastMesh, RaycastMethod, RaycastSource, RaycastSystem,
 };
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(DefaultRaycastingPlugin::<MyRaycastSet>::default())
-        .add_system(
-            update_raycast_with_cursor
-                .in_base_set(CoreSet::First)
-                .before(RaycastSystem::BuildRays::<MyRaycastSet>),
+        .add_plugins((
+            DefaultPlugins,
+            DefaultRaycastingPlugin::<MyRaycastSet>::default(),
+        ))
+        .add_systems(
+            First,
+            update_raycast_with_cursor.before(RaycastSystem::BuildRays::<MyRaycastSet>),
         )
-        .add_system(intersection)
-        .add_startup_system(setup)
+        .add_systems(Startup, setup)
+        .add_systems(Update, intersection)
         .run();
 }
 
@@ -53,7 +54,10 @@ fn setup(
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     commands
-        .spawn(Camera2dBundle::default())
+        .spawn(Camera2dBundle {
+            tonemapping: Tonemapping::ReinhardLuminance,
+            ..default()
+        })
         .insert(RaycastSource::<MyRaycastSet>::new()); // Designate the camera as our source;
     commands
         .spawn(MaterialMesh2dBundle {

--- a/examples/simplified_mesh.rs
+++ b/examples/simplified_mesh.rs
@@ -1,5 +1,6 @@
 use bevy::{
-    diagnostic::{Diagnostics, FrameTimeDiagnosticsPlugin},
+    core_pipeline::tonemapping::Tonemapping,
+    diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin},
     prelude::*,
     window::PresentMode,
 };
@@ -14,27 +15,26 @@ use bevy_mod_raycast::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                present_mode: PresentMode::AutoNoVsync, // Reduces input lag.
-                ..Default::default()
+        .add_plugins((
+            DefaultPlugins.set(WindowPlugin {
+                primary_window: Some(Window {
+                    present_mode: PresentMode::AutoNoVsync, // Reduces input lag.
+                    ..Default::default()
+                }),
+                ..default()
             }),
-            ..default()
-        }))
-        .add_plugin(FrameTimeDiagnosticsPlugin::default())
-        .add_plugin(DefaultRaycastingPlugin::<MyRaycastSet>::default())
+            FrameTimeDiagnosticsPlugin::default(),
+            DefaultRaycastingPlugin::<MyRaycastSet>::default(),
+        ))
         // You will need to pay attention to what order you add systems! Putting them in the wrong
         // order can result in multiple frames of latency. Ray casting should probably happen after
         // the positions of your meshes have been updated in the UPDATE stage.
-        .add_system(
-            update_raycast_with_cursor_position
-                .before(RaycastSystem::BuildRays::<MyRaycastSet>)
-                .in_base_set(CoreSet::First),
+        .add_systems(
+            First,
+            update_raycast_with_cursor_position.before(RaycastSystem::BuildRays::<MyRaycastSet>),
         )
-        .add_startup_system(setup_scene)
-        .add_startup_system(setup_ui)
-        .add_system(update_fps)
-        .add_system(manage_simplified_mesh)
+        .add_systems(Startup, (setup_scene, setup_ui))
+        .add_systems(Update, (update_fps, manage_simplified_mesh))
         .run();
 }
 
@@ -65,7 +65,10 @@ fn setup_scene(
 ) {
     commands.insert_resource(DefaultPluginState::<MyRaycastSet>::default().with_debug_cursor());
     commands
-        .spawn(Camera3dBundle::default())
+        .spawn(Camera3dBundle {
+            tonemapping: Tonemapping::ReinhardLuminance,
+            ..default()
+        })
         .insert(RaycastSource::<MyRaycastSet>::new()); // Designate the camera as our source
     commands.spawn((
         PbrBundle {
@@ -191,7 +194,7 @@ fn manage_simplified_mesh(
     }
 }
 
-fn update_fps(diagnostics: Res<Diagnostics>, mut query: Query<&mut Text, With<FpsText>>) {
+fn update_fps(diagnostics: Res<DiagnosticsStore>, mut query: Query<&mut Text, With<FpsText>>) {
     for mut text in &mut query {
         if let Some(fps) = diagnostics.get(FrameTimeDiagnosticsPlugin::FPS) {
             if let Some(average) = fps.average() {

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -179,7 +179,7 @@ pub mod rays {
     }
 
     /// A 3D ray, with an origin and direction. The direction is guaranteed to be normalized.
-    #[derive(Debug, PartialEq, Copy, Clone, Default)]
+    #[derive(Reflect, Debug, PartialEq, Copy, Clone, Default)]
     pub struct Ray3d {
         pub(crate) origin: Vec3A,
         pub(crate) direction: Vec3A,
@@ -237,11 +237,11 @@ pub mod rays {
         ) -> Option<Self> {
             let view = camera_transform.compute_matrix();
 
-            let (viewport_min, viewport_max) = camera.logical_viewport_rect()?;
+            let viewport = camera.logical_viewport_rect()?;
             let screen_size = camera.logical_target_size()?;
-            let viewport_size = viewport_max - viewport_min;
+            let viewport_size = viewport.max - viewport.min;
             let adj_cursor_pos =
-                cursor_pos_screen - Vec2::new(viewport_min.x, screen_size.y - viewport_max.y);
+                cursor_pos_screen - Vec2::new(viewport.min.x, screen_size.y - viewport.max.y);
 
             let projection = camera.projection_matrix();
             let far_ndc = projection.project_point3(Vec3::NEG_Z).z;


### PR DESCRIPTION
Supersedes #78

# Changes

* Migrate to new `add_systems` API
* Derive `Reflect` instead of using `impl_reflect(_from)_value`
    - Replace `Reflect` type argument bound with `TypePath` (https://bevyengine.org/learn/migration-guides/0.10-0.11/#bevy-reflect-stable-type-path-v2)
* Use `camera.view_to_world()` to implement `Ray3d::from_screenspace` (previous work: #83 #76) (see https://github.com/bevyengine/bevy/pull/8306)
* Explicitly use `ReinhardLuminance` tone mapping in examples (default tone mapping now requires including LUTs)