### PR TITLE
Make Ray3d::from_screenspace start from the near plane

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -11,7 +11,7 @@ pub struct DebugCursor<T> {
 impl<T> Default for DebugCursor<T> {
     fn default() -> Self {
         DebugCursor {
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }
     }
 }
@@ -23,7 +23,7 @@ pub struct DebugCursorMesh<T> {
 impl<T> Default for DebugCursorMesh<T> {
     fn default() -> Self {
         DebugCursorMesh {
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,7 +189,7 @@ impl<T: Reflect + Clone> Default for RaycastSource<T> {
             cast_method: RaycastMethod::Screenspace(Vec2::ZERO),
             ray: None,
             intersections: Vec::new(),
-            _marker: PhantomData::default(),
+            _marker: PhantomData,
         }
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -244,12 +244,10 @@ pub mod rays {
                 cursor_pos_screen - Vec2::new(viewport_min.x, screen_size.y - viewport_max.y);
 
             let projection = camera.projection_matrix();
-            let far_ndc = projection.project_point3(Vec3::NEG_Z).z;
-            let near_ndc = projection.project_point3(Vec3::Z).z;
             let cursor_ndc = (adj_cursor_pos / viewport_size) * 2.0 - Vec2::ONE;
             let ndc_to_world: Mat4 = view * projection.inverse();
-            let near = ndc_to_world.project_point3(cursor_ndc.extend(near_ndc));
-            let far = ndc_to_world.project_point3(cursor_ndc.extend(far_ndc));
+            let near = ndc_to_world.project_point3(cursor_ndc.extend(1.));
+            let far = ndc_to_world.project_point3(cursor_ndc.extend(f32::EPSILON));
             let ray_direction = far - near;
             Some(Ray3d::new(near, ray_direction))
         }


### PR DESCRIPTION
I just made it closer to what bevy does. I think technically what bevy is doing is more correct, as it has the NDC coordinates of the ray origin starting exactly at the near plane (Z=1).

I ran the `simplified_mesh` example and it's still working as expected. If you print the calculated `near` and `far` coordinates for the ray, you'll see that this change makes the ray start at the world-space near plane (Z=-0.1).