### PR TITLE
Fix the mouse_picking example

### DIFF
--- a/examples/mouse_picking.rs
+++ b/examples/mouse_picking.rs
@@ -22,7 +22,8 @@ fn main() {
             First,
             update_raycast_with_cursor.before(RaycastSystem::BuildRays::<MyRaycastSet>),
         )
-        .add_systems(Startup, (setup, print_intersections::<MyRaycastSet>))
+        .add_systems(Startup, setup)
+        .add_systems(Update, print_intersections::<MyRaycastSet>)
         .run();
 }
 
@@ -38,7 +39,9 @@ fn update_raycast_with_cursor(
     mut query: Query<&mut RaycastSource<MyRaycastSet>>,
 ) {
     // Grab the most recent cursor event if it exists:
-    let Some(cursor_moved) = cursor.iter().last() else { return };
+    let Some(cursor_moved) = cursor.iter().last() else {
+        return;
+    };
     for mut pick_source in &mut query {
         pick_source.cast_method = RaycastMethod::Screenspace(cursor_moved.position);
     }
@@ -57,16 +60,6 @@ fn setup(
     commands
         .spawn(Camera3dBundle {
             transform: Transform::from_xyz(-2.0, 2.0, 2.0).looking_at(Vec3::ZERO, Vec3::Y),
-            camera: Camera {
-                // Define a viewport so we can verify screenspace rays are being constructed to
-                // account for viewport size.
-                viewport: Some(bevy::render::camera::Viewport {
-                    physical_position: UVec2::new(200, 200),
-                    physical_size: UVec2::new(400, 400),
-                    ..default()
-                }),
-                ..default()
-            },
             ..default()
         })
         .insert(RaycastSource::<MyRaycastSet>::new()); // Designate the camera as our source

--- a/examples/mouse_picking.rs
+++ b/examples/mouse_picking.rs
@@ -60,6 +60,16 @@ fn setup(
     commands
         .spawn(Camera3dBundle {
             transform: Transform::from_xyz(-2.0, 2.0, 2.0).looking_at(Vec3::ZERO, Vec3::Y),
+            camera: Camera {
+                // Define a viewport so we can verify screenspace rays are being constructed to
+                // account for viewport size.
+                viewport: Some(bevy::render::camera::Viewport {
+                    physical_position: UVec2::new(200, 200),
+                    physical_size: UVec2::new(400, 400),
+                    ..default()
+                }),
+                ..default()
+            },
             ..default()
         })
         .insert(RaycastSource::<MyRaycastSet>::new()); // Designate the camera as our source


### PR DESCRIPTION
Before these changes, the `mouse_picking` example would:
- Not print intersections
Fixed by moving the `print_intersections` method to an Update system
- Shoot a ray from an offsetted mouse position
Fixed by getting rid of the camera viewport settings