### PR TITLE
Include window scale factor in viewport offset calculation

### DIFF
--- a/examples/mouse_picking.rs
+++ b/examples/mouse_picking.rs
@@ -7,7 +7,7 @@ use bevy_mod_raycast::{prelude::*, print_intersections};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(low_latency_window_plugin()))
         // The DefaultRaycastingPlugin bundles all the functionality you might need into a single
         // plugin. This includes building rays, casting them, and placing a debug cursor at the
         // intersection. For more advanced uses, you can compose the systems in this plugin however
@@ -38,7 +38,9 @@ fn update_raycast_with_cursor(
     mut query: Query<&mut RaycastSource<MyRaycastSet>>,
 ) {
     // Grab the most recent cursor event if it exists:
-    let Some(cursor_moved) = cursor.iter().last() else { return };
+    let Some(cursor_moved) = cursor.iter().last() else {
+        return;
+    };
     for mut pick_source in &mut query {
         pick_source.cast_method = RaycastMethod::Screenspace(cursor_moved.position);
     }

--- a/examples/mouse_picking_2d.rs
+++ b/examples/mouse_picking_2d.rs
@@ -25,7 +25,9 @@ fn update_raycast_with_cursor(
     mut query: Query<&mut RaycastSource<MyRaycastSet>>,
 ) {
     // Grab the most recent cursor event if it exists:
-    let Some(cursor_moved) = cursor.iter().last() else { return };
+    let Some(cursor_moved) = cursor.iter().last() else {
+        return;
+    };
     for mut pick_source in &mut query {
         pick_source.cast_method = RaycastMethod::Screenspace(cursor_moved.position);
     }

--- a/examples/simplified_mesh.rs
+++ b/examples/simplified_mesh.rs
@@ -6,20 +6,13 @@ use bevy::{
     core_pipeline::tonemapping::Tonemapping,
     diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin},
     prelude::*,
-    window::PresentMode,
 };
 use bevy_mod_raycast::prelude::*;
 
 fn main() {
     App::new()
         .add_plugins((
-            DefaultPlugins.set(WindowPlugin {
-                primary_window: Some(Window {
-                    present_mode: PresentMode::AutoNoVsync, // Reduces input lag.
-                    ..Default::default()
-                }),
-                ..default()
-            }),
+            DefaultPlugins.set(low_latency_window_plugin()),
             FrameTimeDiagnosticsPlugin,
             DefaultRaycastingPlugin::<MyRaycastSet>::default(),
         ))

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -9,7 +9,6 @@ use bevy::{
     math::Vec3A,
     prelude::*,
     render::primitives::Aabb,
-    window::PresentMode,
 };
 
 use bevy_mod_raycast::prelude::*;
@@ -17,13 +16,7 @@ use bevy_mod_raycast::prelude::*;
 fn main() {
     App::new()
         .add_plugins((
-            DefaultPlugins.set(WindowPlugin {
-                primary_window: Some(Window {
-                    present_mode: PresentMode::AutoNoVsync,
-                    ..default()
-                }),
-                ..default()
-            }),
+            DefaultPlugins.set(low_latency_window_plugin()),
             FrameTimeDiagnosticsPlugin,
             DefaultRaycastingPlugin::<MyRaycastSet>::default(),
         ))

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -162,10 +162,11 @@ pub mod rays {
             cursor_pos_screen: Vec2,
             camera: &Camera,
             camera_transform: &GlobalTransform,
+            window: &Window,
         ) -> Option<Self> {
             let mut viewport_pos = cursor_pos_screen;
             if let Some(viewport) = &camera.viewport {
-                viewport_pos -= viewport.physical_position.as_vec2();
+                viewport_pos -= viewport.physical_position.as_vec2() / window.scale_factor() as f32;
             }
             camera
                 .viewport_to_world(camera_transform, viewport_pos)

--- a/src/system_param.rs
+++ b/src/system_param.rs
@@ -173,8 +173,8 @@ impl<'w, 's> Raycast<'w, 's> {
                         // Does the mesh handle resolve?
                         let mesh_handle = simplified_mesh.map(|m| &m.mesh).unwrap_or(mesh_handle);
                         let Some(mesh) = self.meshes.get(mesh_handle) else {
-                        return
-                    };
+                            return;
+                        };
 
                         let _raycast_guard = raycast_guard.enter();
                         let backfaces = match no_backface_culling {


### PR DESCRIPTION
When working with `bevy_mod_picking` I noticed that pick events are not triggered when I work with a viewport positioned with an offset relative to the window. I tracked issue down to this package. One can reproduce the issue by running `mouse_picking` example on a high density display: the rays will not match with mouse cursor.

Turns out, the viewport offset calculation doesn't take into account pixel density of the screen. We have access to this information in `Window` though. So I make an assumption that we are working with the primary window, and pass the object down to the offset calculation.

I also borrowed helper code for `low_latency_window_plugin` from `bevy_mod_picking` while at it.

This PR fixes one of the root issues https://github.com/aevyrie/bevy_mod_raycast/pull/91 tried to fix symptoms for.

Closes https://github.com/aevyrie/bevy_mod_raycast/issues/93