### PR TITLE
Switch to using individual bevy crates instead of parent "bevy" crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,18 @@ categories = ["game-engines", "rendering"]
 resolver = "2"
 
 [dependencies]
-bevy = { version = "0.11", default-features = false, features = [
-    "bevy_render",
-    "bevy_asset",
-] }
+bevy_app = { version = "0.11", default-features = false }
+bevy_asset = { version = "0.11", default-features = false }
+bevy_derive = { version = "0.11", default-features = false }
+bevy_ecs = { version = "0.11", default-features = false }
+bevy_gizmos = { version = "0.11", optional = true, default-features = false }
+bevy_math = { version = "0.11", default-features = false }
+bevy_reflect = { version = "0.11", default-features = false }
+bevy_render = { version = "0.11", default-features = false }
+bevy_sprite = { version = "0.11", optional = true, default-features = false }
+bevy_transform = { version = "0.11", default-features = false }
+bevy_utils = { version = "0.11", default-features = false }
+bevy_window = { version = "0.11", default-features = false }
 crossbeam-channel = "0.5"
 
 [dev-dependencies]
@@ -29,8 +37,8 @@ criterion = "0.5"
 
 [features]
 default = ["2d", "debug"]
-2d = ["bevy/bevy_sprite"]
-debug = ["bevy/bevy_gizmos"]
+2d = ["bevy_sprite"]
+debug = ["bevy_gizmos"]
 
 [[bench]]
 name = "ray_mesh_intersection"

--- a/src/deferred.rs
+++ b/src/deferred.rs
@@ -153,7 +153,7 @@ impl<T> RaycastPluginState<T> {
 ///
 /// # Requirements
 ///
-/// The marked entity must also have a [Mesh] component.
+/// The marked entity must also have a [Mesh](bevy_render::mesh::Mesh) component.
 #[derive(Component, Debug, Reflect)]
 #[reflect(Component)]
 pub struct RaycastMesh<T: TypePath> {
@@ -312,7 +312,7 @@ impl<T: TypePath> RaycastSource<T> {
     /// present on this entity.
     ///
     /// # Warning
-    /// Only use this if the entity this is associated with will have its [Transform] or
+    /// Only use this if the entity this is associated with will have its [Transform](bevy_transform::components::Transform) or
     /// [GlobalTransform] specified elsewhere. If the [GlobalTransform] is not set, this ray casting
     /// source will never be able to generate a raycast.
     pub fn new_transform_empty() -> Self {

--- a/src/deferred.rs
+++ b/src/deferred.rs
@@ -21,7 +21,14 @@ use std::{
     marker::PhantomData,
 };
 
-use bevy::{prelude::*, reflect::TypePath, render::camera::Camera, window::PrimaryWindow};
+use bevy_app::prelude::*;
+use bevy_ecs::prelude::*;
+use bevy_math::{Mat4, Vec2};
+use bevy_reflect::{Reflect, TypePath};
+use bevy_render::camera::Camera;
+use bevy_transform::components::GlobalTransform;
+use bevy_utils::{default, tracing::*};
+use bevy_window::{PrimaryWindow, Window};
 
 use crate::{immediate::*, primitives::*};
 
@@ -493,7 +500,12 @@ pub fn update_target_intersections<T: TypePath + Send + Sync>(
 pub mod debug {
     #![allow(unused)]
 
-    use bevy::{prelude::*, reflect::TypePath};
+    use bevy_ecs::system::{Commands, Query};
+    use bevy_gizmos::gizmos::Gizmos;
+    use bevy_math::{Quat, Vec3};
+    use bevy_reflect::TypePath;
+    use bevy_render::color::Color;
+    use bevy_utils::tracing::info;
     use std::marker::PhantomData;
 
     use crate::prelude::*;

--- a/src/immediate.rs
+++ b/src/immediate.rs
@@ -10,7 +10,7 @@
 use bevy_asset::{Assets, Handle};
 use bevy_ecs::{prelude::*, system::lifetimeless::Read, system::SystemParam};
 use bevy_reflect::Reflect;
-use bevy_render::{prelude::*, primitives::Aabb, view::ComputedVisibility};
+use bevy_render::{prelude::*, primitives::Aabb};
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::{tracing::*, FloatOrd};
 

--- a/src/immediate.rs
+++ b/src/immediate.rs
@@ -7,12 +7,20 @@
 //! when you call the `cast_ray` method. See the [`Raycast`] documentation for more details. You
 //! don't even need to add a plugin to your application.
 
-use bevy::{
-    ecs::system::{lifetimeless::Read, SystemParam},
-    prelude::*,
-    render::primitives::Aabb,
-    utils::FloatOrd,
+use bevy_asset::{Assets, Handle};
+use bevy_ecs::{prelude::*, system::lifetimeless::Read, system::SystemParam};
+use bevy_math::{Quat, Vec3};
+use bevy_reflect::Reflect;
+use bevy_render::color::Color;
+use bevy_render::{mesh::Mesh, primitives::Aabb, view::ComputedVisibility};
+use bevy_transform::components::GlobalTransform;
+use bevy_utils::{
+    tracing::{debug, debug_span, info_span},
+    FloatOrd,
 };
+
+#[cfg(feature = "debug")]
+use bevy_gizmos::gizmos::Gizmos;
 
 use crate::prelude::*;
 
@@ -82,7 +90,7 @@ impl<'a> Default for RaycastSettings<'a> {
 }
 
 #[cfg(feature = "2d")]
-type MeshFilter = Or<(With<Handle<Mesh>>, With<bevy::sprite::Mesh2dHandle>)>;
+type MeshFilter = Or<(With<Handle<Mesh>>, With<bevy_sprite::Mesh2dHandle>)>;
 #[cfg(not(feature = "2d"))]
 type MeshFilter = With<Handle<Mesh>>;
 
@@ -172,7 +180,7 @@ pub struct Raycast<'w, 's> {
         'w,
         's,
         (
-            Read<bevy::sprite::Mesh2dHandle>,
+            Read<bevy_sprite::Mesh2dHandle>,
             Option<Read<SimplifiedMesh>>,
             Read<GlobalTransform>,
         ),

--- a/src/immediate.rs
+++ b/src/immediate.rs
@@ -9,18 +9,16 @@
 
 use bevy_asset::{Assets, Handle};
 use bevy_ecs::{prelude::*, system::lifetimeless::Read, system::SystemParam};
-use bevy_math::{Quat, Vec3};
 use bevy_reflect::Reflect;
-use bevy_render::color::Color;
-use bevy_render::{mesh::Mesh, primitives::Aabb, view::ComputedVisibility};
+use bevy_render::{prelude::*, primitives::Aabb, view::ComputedVisibility};
 use bevy_transform::components::GlobalTransform;
-use bevy_utils::{
-    tracing::{debug, debug_span, info_span},
-    FloatOrd,
-};
+use bevy_utils::{tracing::*, FloatOrd};
 
 #[cfg(feature = "debug")]
-use bevy_gizmos::gizmos::Gizmos;
+use {
+    bevy_gizmos::gizmos::Gizmos,
+    bevy_math::{Quat, Vec3},
+};
 
 use crate::prelude::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! A small [`bevy`] plugin for raycasting against [`Mesh`]es.
+//! A small `bevy` plugin for raycasting against [`Mesh`](bevy_render::mesh::Mesh)es.
 //!
 //! ```
 //! # use bevy::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,14 @@ pub mod markers;
 pub mod primitives;
 pub mod raycast;
 
-use bevy::prelude::*;
+use bevy_app::prelude::*;
+use bevy_derive::Deref;
+use bevy_ecs::prelude::*;
+use bevy_render::camera::Camera;
+use bevy_transform::components::GlobalTransform;
+use bevy_utils::default;
+use bevy_window::Window;
+
 #[allow(unused_imports)] // Needed for docs
 use prelude::*;
 
@@ -79,7 +86,7 @@ impl Plugin for DefaultRaycastingPlugin {
         app.add_systems(First, update_cursor_ray)
             .add_systems(
                 PostUpdate,
-                update_cursor_ray.after(bevy::transform::TransformSystem::TransformPropagate),
+                update_cursor_ray.after(bevy_transform::TransformSystem::TransformPropagate),
             )
             .init_resource::<CursorRay>();
     }
@@ -96,7 +103,7 @@ pub struct CursorRay(pub Option<Ray3d>);
 
 /// Updates the [`CursorRay`] every frame.
 pub fn update_cursor_ray(
-    primary_window: Query<Entity, With<bevy::window::PrimaryWindow>>,
+    primary_window: Query<Entity, With<bevy_window::PrimaryWindow>>,
     windows: Query<&Window>,
     cameras: Query<(&Camera, &GlobalTransform)>,
     mut cursor_ray: ResMut<CursorRay>,
@@ -104,7 +111,7 @@ pub fn update_cursor_ray(
     cursor_ray.0 = cameras
         .iter()
         .filter_map(|(camera, transform)| {
-            if let bevy::render::camera::RenderTarget::Window(window_ref) = camera.target {
+            if let bevy_render::camera::RenderTarget::Window(window_ref) = camera.target {
                 Some(((camera, transform), window_ref))
             } else {
                 None
@@ -126,10 +133,10 @@ pub fn update_cursor_ray(
 /// Used for examples to reduce picking latency. Not relevant code for the examples.
 #[doc(hidden)]
 #[allow(dead_code)]
-pub fn low_latency_window_plugin() -> bevy::window::WindowPlugin {
-    bevy::window::WindowPlugin {
-        primary_window: Some(bevy::window::Window {
-            present_mode: bevy::window::PresentMode::AutoNoVsync,
+pub fn low_latency_window_plugin() -> bevy_window::WindowPlugin {
+    bevy_window::WindowPlugin {
+        primary_window: Some(bevy_window::Window {
+            present_mode: bevy_window::PresentMode::AutoNoVsync,
             ..default()
         }),
         ..default()

--- a/src/markers.rs
+++ b/src/markers.rs
@@ -1,8 +1,9 @@
-use bevy::prelude::*;
+use bevy_asset::Handle;
+use bevy_ecs::component::Component;
 
 #[derive(Component)]
 pub struct SimplifiedMesh {
-    pub mesh: Handle<bevy::render::mesh::Mesh>,
+    pub mesh: Handle<bevy_render::mesh::Mesh>,
 }
 
 #[derive(Component)]

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,4 +1,5 @@
-use bevy::{math::Vec3A, prelude::*};
+use bevy_math::{Vec3, Vec3A};
+use bevy_reflect::Reflect;
 
 pub use rays::*;
 
@@ -65,11 +66,11 @@ impl IntersectionData {
 /// the `Ray3d` direction is normalized, because it can only be instantiated with the constructor.
 pub mod rays {
     use super::Primitive3d;
-    use bevy::{
-        math::{Ray, Vec3A},
-        prelude::*,
-        render::{camera::Camera, primitives::Aabb},
-    };
+    use bevy_math::{prelude::*, Vec3A};
+    use bevy_reflect::Reflect;
+    use bevy_render::{camera::Camera, primitives::Aabb};
+    use bevy_transform::components::GlobalTransform;
+    use bevy_window::Window;
 
     pub struct PrimitiveIntersection {
         position: Vec3,

--- a/src/raycast.rs
+++ b/src/raycast.rs
@@ -1,13 +1,11 @@
 use std::f32::EPSILON;
 
-use bevy::{
-    math::Vec3A,
-    prelude::*,
-    render::{
-        mesh::{Indices, VertexAttributeValues},
-        render_resource::PrimitiveTopology,
-    },
+use bevy_math::{Mat4, Vec3A};
+use bevy_render::{
+    mesh::{Indices, Mesh, VertexAttributeValues},
+    render_resource::PrimitiveTopology,
 };
+use bevy_utils::tracing::{error, warn};
 
 use crate::primitives::*;
 


### PR DESCRIPTION
Converted the mod to use the individual bevy crates as dependencies instead of the just the parent crate ("bevy"). Following the lead on some of other mods in this family (eventlistener, picking etc.)