### PR TITLE
Add optional indices to IntersectionData.

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -14,6 +14,7 @@ pub struct IntersectionData {
     normal: Vec3,
     distance: f32,
     triangle: Option<Triangle>,
+    indices: Option<[usize; 3]>,
 }
 
 impl From<rays::PrimitiveIntersection> for IntersectionData {
@@ -23,17 +24,25 @@ impl From<rays::PrimitiveIntersection> for IntersectionData {
             normal: data.normal(),
             distance: data.distance(),
             triangle: None,
+            indices: None,
         }
     }
 }
 
 impl IntersectionData {
-    pub fn new(position: Vec3, normal: Vec3, distance: f32, triangle: Option<Triangle>) -> Self {
+    pub fn new(
+        position: Vec3,
+        normal: Vec3,
+        distance: f32,
+        triangle: Option<Triangle>,
+        indices: Option<[usize; 3]>,
+    ) -> Self {
         Self {
             position,
             normal,
             distance,
             triangle,
+            indices,
         }
     }
 
@@ -59,6 +68,11 @@ impl IntersectionData {
     #[must_use]
     pub fn triangle(&self) -> Option<Triangle> {
         self.triangle
+    }
+
+    /// Get the intersection triangle's indices.
+    pub fn indices(&self) -> Option<[usize; 3]> {
+        self.indices
     }
 }
 

--- a/src/raycast.rs
+++ b/src/raycast.rs
@@ -150,6 +150,11 @@ pub fn ray_mesh_intersection(
                             mesh_transform.transform_point3a(tri.v2),
                         ])
                     }),
+                    Some([
+                        index[0].into_usize(),
+                        index[1].into_usize(),
+                        index[2].into_usize(),
+                    ]),
                 ));
                 min_pick_distance = i.distance();
             }
@@ -175,6 +180,7 @@ pub fn ray_mesh_intersection(
                 mesh_space_ray,
                 backface_culling,
             );
+            let indices = Some([i, i + 1, i + 2]);
             if let Some(i) = intersection {
                 pick_intersection = Some(IntersectionData::new(
                     mesh_transform.transform_point3(i.position()),
@@ -189,6 +195,7 @@ pub fn ray_mesh_intersection(
                             mesh_transform.transform_point3a(tri.v2),
                         ])
                     }),
+                    indices,
                 ));
                 min_pick_distance = i.distance();
             }
@@ -228,6 +235,7 @@ fn triangle_intersection(
                     normal.into(),
                     distance,
                     Some(tri_vertices.to_triangle()),
+                    None,
                 );
                 return Some(intersection);
             }


### PR DESCRIPTION
Vertex indices are exposed via `IntersectionData `.
This allows for getting additional data like vertex attributes and UVs.

I have implemented it to be able to query the texture color at the mouse pointer.