### PR TITLE
Unify triangle_index for indexed and non-indexed meshes

### DIFF
--- a/src/raycast.rs
+++ b/src/raycast.rs
@@ -114,18 +114,18 @@ pub fn ray_mesh_intersection(
         // Now that we're in the vector of vertex indices, we want to look at the vertex
         // positions for each triangle, so we'll take indices in chunks of three, where each
         // chunk of three indices are references to the three vertices of a triangle.
-        for index in indices.chunks(3) {
-            let triangle_index = Some(index[0].into_usize());
+        for i in (0..indices.len()).step_by(3) {
+            let triangle_index = Some(i);
             let tri_vertex_positions = [
-                Vec3A::from(vertex_positions[index[0].into_usize()]),
-                Vec3A::from(vertex_positions[index[1].into_usize()]),
-                Vec3A::from(vertex_positions[index[2].into_usize()]),
+                Vec3A::from(vertex_positions[indices[i].into_usize()]),
+                Vec3A::from(vertex_positions[indices[i + 1].into_usize()]),
+                Vec3A::from(vertex_positions[indices[i + 2].into_usize()]),
             ];
             let tri_normals = vertex_normals.map(|normals| {
                 [
-                    Vec3A::from(normals[index[0].into_usize()]),
-                    Vec3A::from(normals[index[1].into_usize()]),
-                    Vec3A::from(normals[index[2].into_usize()]),
+                    Vec3A::from(normals[indices[i].into_usize()]),
+                    Vec3A::from(normals[indices[i + 1].into_usize()]),
+                    Vec3A::from(normals[indices[i + 2].into_usize()]),
                 ]
             });
             let intersection = triangle_intersection(

--- a/src/raycast.rs
+++ b/src/raycast.rs
@@ -171,7 +171,6 @@ pub fn ray_mesh_intersection(
             min_pick_distance = i.distance();
         }
     }
-
     pick_intersection
 }
 


### PR DESCRIPTION
For indexed meshes `triangle_index` contained the (looked up / resolved) index of the first vertex of the triangle. This made it impossible to find the other two vertices because there was no data on the triangle (one vertex can belong to multiple triangles).

This PR unifies the way how indexed and non-indexed meshes are handled without increasing the size of the `IntersectionData` struct. In turn the users have to implement the lookup of the indices themselves. In my case I'm using a function like this:

```
fn get_indices(mesh: &Mesh, intersection: &IntersectionData) -> Result<(usize, usize, usize)> {
    let i = intersection
        .triangle_index()
        .ok_or_eyre("Intersection Index not found")?;

    Ok(mesh.indices().map_or_else(
        || (i, i + 1, i + 2),
        |indices| match indices {
            Indices::U16(indices) => (
                indices[i].into_usize(),
                indices[i + 1].into_usize(),
                indices[i + 2].into_usize(),
            ),
            Indices::U32(indices) => (
                indices[i].into_usize(),
                indices[i + 1].into_usize(),
                indices[i + 2].into_usize(),
            ),
        },
    ))
}
```

Maybe this could be added as convenience function to `IntersectionData` or `Mesh` in the future?

This PR addresses the issues discussed here:
- #77
- #103
- #107
- #113