### PR TITLE
Fix edge of mesh intersections being filtered out due to returning NaN

### DIFF
--- a/src/immediate.rs
+++ b/src/immediate.rs
@@ -257,7 +257,8 @@ impl<'w, 's> Raycast<'w, 's> {
                 };
                 if should_raycast {
                     if let Some([near, _]) = intersects_aabb(ray, aabb, &transform.compute_matrix())
-                        .filter(|[_, far]| *far >= 0.0)
+                        // intersections on edge of mesh may return [NaN,NaN]
+                        .filter(|[_, far]| *far >= 0.0 || far.is_nan())
                     {
                         aabb_hits_tx.send((FloatOrd(near), entity)).ok();
                     }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -162,6 +162,7 @@ pub mod rays {
     }
 
     /// Checks if the ray intersects with an AABB of a mesh, returning `[near, far]` if it does.
+    /// Intersections on the edge of meshes may return [NaN, NaN]
     pub fn intersects_aabb(ray: Ray3d, aabb: &Aabb, model_to_world: &Mat4) -> Option<[f32; 2]> {
         // Transform the ray to model space
         let world_to_model = model_to_world.inverse();


### PR DESCRIPTION
Fixes: https://github.com/aevyrie/bevy_mod_raycast/issues/118

I still think a better approach exists to fix this, but I wanted to confirm the tests pass. And, if I'm wrong about a better fix existing, then this will be here for convenience