### PR TITLE
fix: Derives Clone, Debug, Default, Reflect on SimplifiedMesh

### DIFF
--- a/src/markers.rs
+++ b/src/markers.rs
@@ -1,7 +1,9 @@
 use bevy_asset::Handle;
-use bevy_ecs::component::Component;
+use bevy_ecs::{component::Component, reflect::ReflectComponent};
+use bevy_reflect::Reflect;
 
-#[derive(Component)]
+#[derive(Component, Clone, Debug, Default, Reflect)]
+#[reflect(Component)]
 pub struct SimplifiedMesh {
     pub mesh: Handle<bevy_render::mesh::Mesh>,
 }


### PR DESCRIPTION
## Description

`SimplifiedMesh` doesn't derive/implement a lot of the traits that `Handle<Mesh>` does.  This PR derives all those traits.