### PR TITLE
Add CursorRayCam component to filter cameras used by CursorRayPlugin

### DIFF
--- a/examples/mouse_picking.rs
+++ b/examples/mouse_picking.rs
@@ -25,7 +25,7 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands.spawn(Camera3dBundle::default());
+    commands.spawn((Camera3dBundle::default(), CursorRayCam));
     commands.spawn(PointLightBundle::default());
     commands.spawn(PbrBundle {
         mesh: meshes.add(Sphere::default()),

--- a/examples/reflecting_laser.rs
+++ b/examples/reflecting_laser.rs
@@ -94,6 +94,7 @@ fn setup_scene(
             ..default()
         },
         BloomSettings::default(),
+        CursorRayCam,
     ));
     // Make a box of planes facing inward so the laser gets trapped inside:
     let plane = PbrBundle {

--- a/examples/simplified_mesh.rs
+++ b/examples/simplified_mesh.rs
@@ -33,7 +33,7 @@ fn setup_scene(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands.spawn(Camera3dBundle::default());
+    commands.spawn((Camera3dBundle::default(), CursorRayCam));
     commands.spawn((
         PbrBundle {
             // This is a very complex mesh that will be hard to raycast on

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -8,7 +8,7 @@ use bevy_window::Window;
 
 use crate::ray_from_screenspace;
 
-/// Automatically generates a ray in world space corresponding to the mouse cursor, and stores it in
+/// Automatically generates a ray in world space corresponding to the mouse cursor and [`CursorRayCam`] marked camera(s), then stores it in
 /// [`CursorRay`].
 #[derive(Default)]
 pub struct CursorRayPlugin;
@@ -23,6 +23,10 @@ impl Plugin for CursorRayPlugin {
     }
 }
 
+/// Marks the camera this component is attached to as a [`CursorRay`] ray source.
+#[derive(Component)]
+pub struct CursorRayCam;
+
 /// Holds the latest cursor position as a 3d ray.
 ///
 /// Requires the [`CursorRayPlugin`] is added to your app. This is updated in both [`First`] and
@@ -36,7 +40,7 @@ pub struct CursorRay(pub Option<Ray3d>);
 pub fn update_cursor_ray(
     primary_window: Query<Entity, With<bevy_window::PrimaryWindow>>,
     windows: Query<&Window>,
-    cameras: Query<(&Camera, &GlobalTransform)>,
+    cameras: Query<(&Camera, &GlobalTransform), With<CursorRayCam>>,
     mut cursor_ray: ResMut<CursorRay>,
 ) {
     cursor_ray.0 = cameras


### PR DESCRIPTION
I'm using the `CursorRayPlugin` for my project, but currently, `update_cursor_ray` updates the `CursorRay` based on *every* camera in the world with no filter options. This breaks the plugin for my project which uses multiple cameras.

This pr fixes this by adding the `CursorRayCam` component to attach to cameras to mark them as targets for the `CursorRayPlugin`.